### PR TITLE
DM-10095: Fix jointcal specification formatting

### DIFF
--- a/specs/jointcal/astrometry_chisq.yaml
+++ b/specs/jointcal/astrometry_chisq.yaml
@@ -9,6 +9,7 @@ id: 'astrometry_chisq-base'
 metric: 'astrometry_chisq'
 threshold:
   operator: "<="
+  unit: ''
 
 ---
 name: "maximum"

--- a/specs/jointcal/astrometry_ndof.yaml
+++ b/specs/jointcal/astrometry_ndof.yaml
@@ -6,3 +6,4 @@ id: 'astrometry_ndof-base'
 metric: 'astrometry_ndof'
 threshold:
   operator: "=="
+  unit: ''

--- a/specs/jointcal/hsc_r.yaml
+++ b/specs/jointcal/hsc_r.yaml
@@ -10,34 +10,33 @@ provenance_query:
 ---
 # jointcal.astrometry_ndof.hsc_11_visits
 name: "hsc_11_visits"
-  base: astrometry_ndof.yaml#astrometry_ndof-base
-  provenance_query:
-    # Prototype for query provenance. This needs to be figured out.
-    visits: [903334, 903336, 903338, 903342, 903344, 903346, 903986, 903988, 903990, 904010, 904014]
-    config: 'config.astrometryModel="simplePoly"'
+base: ["#base", "astrometry_ndof#astrometry_ndof-base"]
+provenance_query:
+  # Prototype for query provenance. This needs to be figured out.
+  visits: [903334, 903336, 903338, 903342, 903344, 903346, 903986, 903988, 903990, 904010, 904014]
+  config: 'config.astrometryModel="simplePoly"'
 threshold:
   value: 14262
 
 ---
 # jointcal.astrometry_ndof.hsc_2_visits
 name: "hsc_2_visits"
-  base: astrometry_ndof.yaml#astrometry_ndof-base
-  provenance_query:
-    # Prototype for query provenance. This needs to be figured out.
-    dataset_repo_url: 'https://github.com/lsst/testdata_jointcal.git'
-    visits: [903334, 903336]
-    config: 'config.astrometryModel="simplePoly"'
+base: ["#base", "astrometry_ndof#astrometry_ndof-base"]
+provenance_query:
+  # Prototype for query provenance. This needs to be figured out.
+  visits: [903334, 903336]
+  config: 'config.astrometryModel="simplePoly"'
 threshold:
   value: 1858
 
 ---
 # jointcal.astrometry_chisq.hsc_2_visits_gaia_refcat
 name: "hsc_2_visits_gaia_refcat"
-  base: astrometry_ndof.yaml#astrometry_ndof-base
-  provenance_query:
-    # Prototype for query provenance. This needs to be figured out.
-    dataset_repo_url: 'https://github.com/lsst/testdata_jointcal.git'
-    visits: [903334, 903336]
-    config: 'config.astrometryModel="simplePoly"'
-    config: 'config.astrometryRefObjLoader="LoadIndexedReferenceObjectsTask"'
+base: ["#base", "astrometry_ndof#astrometry_ndof-base"]
+provenance_query:
+  # Prototype for query provenance. This needs to be figured out.
+  visits: [903334, 903336]
+  config: 'config.astrometryModel="simplePoly"'
+  config: 'config.astrometryRefObjLoader="LoadIndexedReferenceObjectsTask"'
+threshold:
   value: 504


### PR DESCRIPTION
- Adds a `unit` to `#astrometry_chisq-base` and `#astrometry_ndof-base`'s threshold.

- Fixes an indentation issue with specifications in `hsc_r.yaml`.

- Use the `#base` in partial in `hsc_r.yaml` specifications.

This should be parseable with `validate_base`'s `SpecificationSet` as of DM-9559.