### PR TITLE
[DM-15165] Add new tags for validate_drp metric definition and specifications

### DIFF
--- a/metrics/validate_drp.yaml
+++ b/metrics/validate_drp.yaml
@@ -10,6 +10,7 @@ PA1:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PF1_minimum_gri:
   description: >
@@ -19,6 +20,7 @@ PF1_minimum_gri:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PF1_design_gri:
   description: >
@@ -28,6 +30,7 @@ PF1_design_gri:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PF1_stretch_gri:
   description: >
@@ -37,6 +40,7 @@ PF1_stretch_gri:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PF1_minimum_uzy:
   description: >
@@ -46,6 +50,7 @@ PF1_minimum_uzy:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PF1_design_uzy:
   description: >
@@ -55,6 +60,7 @@ PF1_design_uzy:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PF1_stretch_uzy:
   description: >
@@ -64,6 +70,7 @@ PF1_stretch_uzy:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PA2_minimum_gri:
   description: >
@@ -73,6 +80,7 @@ PA2_minimum_gri:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PA2_design_gri:
   description: >
@@ -82,6 +90,7 @@ PA2_design_gri:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PA2_stretch_gri:
   description: >
@@ -91,6 +100,7 @@ PA2_stretch_gri:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PA2_minimum_uzy:
   description: >
@@ -100,6 +110,7 @@ PA2_minimum_uzy:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PA2_design_uzy:
   description: >
@@ -109,6 +120,7 @@ PA2_design_uzy:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 PA2_stretch_uzy:
   description: >
@@ -118,6 +130,7 @@ PA2_stretch_uzy:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 21
+  tags: photometry
 
 AM1:
   description: >
@@ -127,6 +140,7 @@ AM1:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AM2:
   description: >
@@ -136,6 +150,7 @@ AM2:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AM3:
   description: >
@@ -145,6 +160,7 @@ AM3:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AF1_minimum:
   description: >
@@ -154,6 +170,7 @@ AF1_minimum:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AF1_design:
   description: >
@@ -163,6 +180,7 @@ AF1_design:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AF1_stretch:
   description: >
@@ -172,6 +190,7 @@ AF1_stretch:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AF2_minimum:
   description: >
@@ -181,6 +200,7 @@ AF2_minimum:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AF2_design:
   description: >
@@ -190,6 +210,7 @@ AF2_design:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AF2_stretch:
   description: >
@@ -199,6 +220,7 @@ AF2_stretch:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AF3_minimum:
   reference:
@@ -208,6 +230,7 @@ AF3_minimum:
   unit: '%'
   description: >
     The maximum fraction of astrometric distances which deviate by more than AD3 milliarcsec (see AM3).
+  tags: astrometry
 
 AF3_design:
   reference:
@@ -217,6 +240,7 @@ AF3_design:
   unit: '%'
   description: >
     The maximum fraction of astrometric distances which deviate by more than AD3 milliarcsec (see AM3).
+  tags: astrometry
 
 AF3_stretch:
   reference:
@@ -226,6 +250,7 @@ AF3_stretch:
   unit: '%'
   description: >
     The maximum fraction of astrometric distances which deviate by more than AD3 milliarcsec (see AM3).
+  tags: astrometry
 
 AD1_minimum:
   description: >
@@ -235,6 +260,7 @@ AD1_minimum:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AD1_design:
   description: >
@@ -244,6 +270,7 @@ AD1_design:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AD1_stretch:
   description: >
@@ -253,6 +280,7 @@ AD1_stretch:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AD2_minimum:
   description: >
@@ -262,6 +290,7 @@ AD2_minimum:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AD2_design:
   description: >
@@ -271,6 +300,7 @@ AD2_design:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AD2_stretch:
   description: >
@@ -280,6 +310,7 @@ AD2_stretch:
     doc: LPM-17
     url: http://ls.st/lpm-17
     page: 23
+  tags: astrometry
 
 AD3_minimum:
   reference:
@@ -289,6 +320,7 @@ AD3_minimum:
   unit: milliarcsecond
   description: >
     No more than AF3 of the astrometric distances will deviate by more than this from the median (see AM3, AF3).
+  tags: astrometry
 
 AD3_design:
   reference:
@@ -298,6 +330,7 @@ AD3_design:
   unit: milliarcsecond
   description: >
     No more than AF3 of the astrometric distances will deviate by more than this from the median (see AM3, AF3).
+  tags: astrometry
 
 AD3_stretch:
   reference:
@@ -307,6 +340,7 @@ AD3_stretch:
   unit: milliarcsecond
   description: >
     No more than AF3 of the astrometric distances will deviate by more than this from the median (see AM3, AF3).
+  tags: astrometry
 
 TE1:
   reference:
@@ -317,6 +351,7 @@ TE1:
   description: >
     The averaged E1, E2, and Ex residual PSF ellipticity correlations
     must have median absolute value less than this for separations < 1 arcmin.
+  tags: image_quality
 
 TE2:
   reference:
@@ -327,3 +362,4 @@ TE2:
   description: >
     The averaged E1, E2, and Ex residual PSF ellipticity correlations
     must have median absolute value less than this for separations > 5 arcmin.
+  tags: image_quality

--- a/specs/validate_drp/ADx.yaml
+++ b/specs/validate_drp/ADx.yaml
@@ -34,6 +34,8 @@ name: "srd"
 base: "#AD1-base"
 threshold:
   value: 20.0
+tags:
+  - design
 
 ---
 metric: "AD1_minimum"
@@ -41,6 +43,8 @@ name: "srd"
 base: "#AD1-base"
 threshold:
   value: 40.0
+tags:
+  - minimum
 
 ---
 metric: "AD1_stretch"
@@ -48,6 +52,8 @@ name: "srd"
 base: "#AD1-base"
 threshold:
   value: 10.0
+tags:
+  - stretch
 
 ---
 metric: "AD2_design"
@@ -55,6 +61,8 @@ name: "srd"
 base: "#AD2-base"
 threshold:
   value: 20.0
+tags:
+  - design
 
 ---
 metric: "AD2_minimum"
@@ -62,6 +70,8 @@ name: "srd"
 base: "#AD2-base"
 threshold:
   value: 40.0
+tags:
+  - minimum
 
 ---
 metric: "AD2_stretch"
@@ -69,6 +79,8 @@ name: "srd"
 base: "#AD2-base"
 threshold:
   value: 10.0
+tags:
+  - stretch
 
 ---
 metric: "AD3_design"
@@ -76,6 +88,8 @@ name: "srd"
 base: "#AD3-base"
 threshold:
   value: 30.0
+tags:
+  - design
 
 ---
 metric: "AD3_minimum"
@@ -83,6 +97,8 @@ name: "srd"
 base: "#AD3-base"
 threshold:
   value: 50.0
+tags:
+  - minimum
 
 ---
 metric: "AD3_stretch"
@@ -90,3 +106,5 @@ name: "srd"
 base: "#AD3-base"
 threshold:
   value: 20.0
+tags:
+  - stretch

--- a/specs/validate_drp/AFx.yaml
+++ b/specs/validate_drp/AFx.yaml
@@ -34,6 +34,8 @@ name: "srd"
 base: "#AF1-base"
 threshold:
   value: 10.0
+tags:
+  - design
 
 ---
 metric: "AF1_minimum"
@@ -41,6 +43,8 @@ name: "srd"
 base: "#AF1-base"
 threshold:
   value: 20.0
+tags:
+  - minimum
 
 ---
 metric: "AF1_stretch"
@@ -48,6 +52,8 @@ name: "srd"
 base: "#AF1-base"
 threshold:
   value: 5.0
+tags:
+  - stretch
 
 ---
 metric: "AF2_design"
@@ -55,6 +61,8 @@ name: "srd"
 base: "#AF2-base"
 threshold:
   value: 10.0
+tags:
+  - design
 
 ---
 metric: "AF2_minimum"
@@ -62,6 +70,8 @@ name: "srd"
 base: "#AF2-base"
 threshold:
   value: 20.0
+tags:
+  - minimum
 
 ---
 metric: "AF2_stretch"
@@ -69,6 +79,8 @@ name: "srd"
 base: "#AF2-base"
 threshold:
   value: 5.0
+tags:
+  - stretch
 
 ---
 metric: "AF3_design"
@@ -76,6 +88,8 @@ name: "srd"
 base: "#AF3-base"
 threshold:
   value: 10.0
+tags:
+  - design
 
 ---
 metric: "AF3_minimum"
@@ -83,6 +97,8 @@ name: "srd"
 base: "#AF3-base"
 threshold:
   value: 20.0
+tags:
+  - minimum
 
 ---
 metric: "AF3_stretch"
@@ -90,3 +106,5 @@ name: "srd"
 base: "#AF3-base"
 threshold:
   value: 5.0
+tags:
+  - stretch

--- a/specs/validate_drp/AMx.yaml
+++ b/specs/validate_drp/AMx.yaml
@@ -36,51 +36,69 @@ name: "design"
 base: "#AM1-base"
 threshold:
   value: 10.0
+tags:
+  - design
 
 ---
 name: "minimum"
 base: "#AM1-base"
 threshold:
   value: 20.0
+tags:
+  - minimum
 
 ---
 name: "stretch"
 base: "#AM1-base"
 threshold:
   value: 5.0
+tags:
+  - stretch
 
 ---
 name: "design"
 base: "#AM2-base"
 threshold:
   value: 10.0
+tags:
+  - design
 
 ---
 name: "minimum"
 base: "#AM2-base"
 threshold:
   value: 20.0
+tags:
+  - minimum
 
 ---
 name: "stretch"
 base: "#AM2-base"
 threshold:
   value: 5.0
----
+tags:
+  - stretch
 
+---
 name: "design"
 base: "#AM3-base"
 threshold:
   value: 15.0
+tags:
+  - design
 
 ---
 name: "minimum"
 base: "#AM3-base"
 threshold:
   value: 30.0
+tags:
+  - minimum
 
 ---
 name: "stretch"
 base: "#AM3-base"
 threshold:
   value: 10.0
+tags:
+  - stretch

--- a/specs/validate_drp/LPM-17-PA1.yaml
+++ b/specs/validate_drp/LPM-17-PA1.yaml
@@ -19,33 +19,45 @@ name: "minimum_gri"
 base: "#PA1-base"
 threshold:
   value: 8.0
+tags:
+  - minimum
 
 ---
 name: "design_gri"
 base: "#PA1-base"
 threshold:
   value: 5.0
+tags:
+  - design
 
 ---
 name: "stretch_gri"
 base: "#PA1-base"
 threshold:
   value: 3.0
+tags:
+  - stretch
 
 ---
 name: "minimum_uzy"
 base: "#PA1-base"
 threshold:
   value: 12.0
+tags:
+  - minimum
 
 ---
 name: "design_uzy"
 base: "#PA1-base"
 threshold:
   value: 7.5
+tags:
+  - design
 
 ---
 name: "stretch_uzy"
 base: "#PA1-base"
 threshold:
   value: 4.5
+tags:
+  - stretch

--- a/specs/validate_drp/LPM-17-PA2.yaml
+++ b/specs/validate_drp/LPM-17-PA2.yaml
@@ -20,6 +20,8 @@ name: 'srd'
 base: '#PA2-base'
 threshold:
   value: 15.0
+tags:
+  - minimum
 
 ---
 # validate_drp.PA2_design_gri.srd
@@ -28,6 +30,8 @@ name: 'srd'
 base: '#PA2-base'
 threshold:
   value: 15.0
+tags:
+  - design
 
 ---
 # validate_drp.PA2_stretch_gri.srd
@@ -36,6 +40,8 @@ name: 'srd'
 base: '#PA2-base'
 threshold:
   value: 10.0
+tags:
+  - stretch
 
 ---
 # validate_drp.PA2_minimum_uzy.srd
@@ -44,6 +50,8 @@ name: 'srd'
 base: '#PA2-base'
 threshold:
   value: 22.5
+tags:
+  - minimum
 
 ---
 # validate_drp.PA2_design_uzy.srd
@@ -52,6 +60,8 @@ name: 'srd'
 base: '#PA2-base'
 threshold:
   value: 22.5
+tags:
+  - design
 
 ---
 # validate_drp.PA2_stretch_uzy.srd
@@ -60,3 +70,5 @@ name: 'srd'
 base: '#PA2-base'
 threshold:
   value: 15.0
+tags:
+  - stretch

--- a/specs/validate_drp/LPM-17-PF1.yaml
+++ b/specs/validate_drp/LPM-17-PF1.yaml
@@ -20,6 +20,8 @@ name: 'srd'
 base: '#PF1-base'
 threshold:
   value: 20.0
+tags:
+  - minimum
 
 ---
 # validate_drp.PF1_design_gri.srd
@@ -28,6 +30,8 @@ name: 'srd'
 base: '#PF1-base'
 threshold:
   value: 10.0
+tags:
+  - design
 
 ---
 # validate_drp.PF1_stretch_gri.srd
@@ -36,6 +40,8 @@ name: 'srd'
 base: '#PF1-base'
 threshold:
   value: 5.0
+tags:
+  - stretch
 
 ---
 # validate_drp.PF1_minimum_uzy.srd
@@ -44,6 +50,8 @@ name: 'srd'
 base: '#PF1-base'
 threshold:
   value: 20.0
+tags:
+  - minimum
 
 ---
 # validate_drp.PF1_design_uzy.srd
@@ -52,6 +60,8 @@ name: 'srd'
 base: '#PF1-base'
 threshold:
   value: 10.0
+tags:
+  - design
 
 ---
 # validate_drp.PF1_stretch_uzy.srd
@@ -60,3 +70,5 @@ name: 'srd'
 base: '#PF1-base'
 threshold:
   value: 5.0
+tags:
+  - stretch

--- a/specs/validate_drp/TEx.yaml
+++ b/specs/validate_drp/TEx.yaml
@@ -26,33 +26,45 @@ name: "design"
 base: "#TE1-base"
 threshold:
   value: 0.00002
+tags:
+  - design
 
 ---
 name: "minimum"
 base: "#TE1-base"
 threshold:
   value: 0.00003
+tags:
+  - minimum
 
 ---
 name: "stretch"
 base: "#TE1-base"
 threshold:
   value: 0.00001
+tags:
+  - stretch
 
 ---
 name: "design"
 base: "#TE2-base"
 threshold:
   value: 0.00005
+tags:
+  - design
 
 ---
 name: "minimum"
 base: "#TE2-base"
 threshold:
   value: 0.00003
+tags:
+  - minimum
 
 ---
 name: "stretch"
 base: "#TE2-base"
 threshold:
   value: 0.00001
+tags:
+  - stretch

--- a/specs/validate_drp/cfht_gri/PA1.yaml
+++ b/specs/validate_drp/cfht_gri/PA1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA1.cfht_design_g
 name: 'cfht_design_g'
-base: ['PA1.design_gri', 'cfht_gri/base#base-g']
+base: ['PA1.design_gri', 'cfht_gri/base#cfht-g']
 
 ---
 # validate_drp.PA1.cfht_design_r
 name: 'cfht_design_r'
-base: ['PA1.design_gri', 'cfht_gri/base#base-r']
+base: ['PA1.design_gri', 'cfht_gri/base#cfht-r']
 
 ---
 # validate_drp.PA1.cfht_design_i
 name: 'cfht_design_i'
-base: ['PA1.design_gri', 'cfht_gri/base#base-i']
+base: ['PA1.design_gri', 'cfht_gri/base#cfht-i']
 
 ---
 # validate_drp.PA1.cfht_minimum_g
 name: 'cfht_minimum_g'
-base: ['PA1.minimum_gri', 'cfht_gri/base#base-g']
+base: ['PA1.minimum_gri', 'cfht_gri/base#cfht-g']
 
 ---
 # validate_drp.PA1.cfht_minimum_r
 name: 'cfht_minimum_r'
-base: ['PA1.minimum_gri', 'cfht_gri/base#base-r']
+base: ['PA1.minimum_gri', 'cfht_gri/base#cfht-r']
 
 ---
 # validate_drp.PA1.cfht_minimum_i
 name: 'cfht_minimum_i'
-base: ['PA1.minimum_gri', 'cfht_gri/base#base-i']
+base: ['PA1.minimum_gri', 'cfht_gri/base#cfht-i']
 
 ---
 # validate_drp.PA1.cfht_stretch_g
 name: 'cfht_stretch_g'
-base: ['PA1.stretch_gri', 'cfht_gri/base#base-g']
+base: ['PA1.stretch_gri', 'cfht_gri/base#cfht-g']
 
 ---
 # validate_drp.PA1.cfht_stretch_r
 name: 'cfht_stretch_r'
-base: ['PA1.stretch_gri', 'cfht_gri/base#base-r']
+base: ['PA1.stretch_gri', 'cfht_gri/base#cfht-r']
 
 ---
 # validate_drp.PA1.cfht_stretch_i
 name: 'cfht_stretch_i'
-base: ['PA1.stretch_gri', 'cfht_gri/base#base-i']
+base: ['PA1.stretch_gri', 'cfht_gri/base#cfht-i']

--- a/specs/validate_drp/cfht_gri/PA2.yaml
+++ b/specs/validate_drp/cfht_gri/PA2.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA2_minimum_gri.cfht_g
 name: 'cfht_g'
-base: ['PA2_minimum_gri.srd', 'cfht_gri/base#base-g']
+base: ['PA2_minimum_gri.srd', 'cfht_gri/base#cfht-g']
 
 ---
 # validate_drp.PA2_minimum_gri.cfht_r
 name: 'cfht_r'
-base: ['PA2_minimum_gri.srd', 'cfht_gri/base#base-r']
+base: ['PA2_minimum_gri.srd', 'cfht_gri/base#cfht-r']
 
 ---
 # validate_drp.PA2_minimum_gri.cfht_i
 name: 'cfht_i'
-base: ['PA2_minimum_gri.srd', 'cfht_gri/base#base-i']
+base: ['PA2_minimum_gri.srd', 'cfht_gri/base#cfht-i']
 
 ---
 # validate_drp.PA2_design_gri.cfht_g
 name: 'cfht_g'
-base: ['PA2_design_gri.srd', 'cfht_gri/base#base-g']
+base: ['PA2_design_gri.srd', 'cfht_gri/base#cfht-g']
 
 ---
 # validate_drp.PA2_design_gri.cfht_r
 name: 'cfht_r'
-base: ['PA2_design_gri.srd', 'cfht_gri/base#base-r']
+base: ['PA2_design_gri.srd', 'cfht_gri/base#cfht-r']
 
 ---
 # validate_drp.PA2_design_gri.cfht_i
 name: 'cfht_i'
-base: ['PA2_design_gri.srd', 'cfht_gri/base#base-i']
+base: ['PA2_design_gri.srd', 'cfht_gri/base#cfht-i']
 
 ---
 # validate_drp.PA2_stretch_gri.cfht_g
 name: 'cfht_g'
-base: ['PA2_stretch_gri.srd', 'cfht_gri/base#base-g']
+base: ['PA2_stretch_gri.srd', 'cfht_gri/base#cfht-g']
 
 ---
 # validate_drp.PA2_stretch_gri.cfht_r
 name: 'cfht_r'
-base: ['PA2_stretch_gri.srd', 'cfht_gri/base#base-r']
+base: ['PA2_stretch_gri.srd', 'cfht_gri/base#cfht-r']
 
 ---
 # validate_drp.PA2_stretch_gri.cfht_i
 name: 'cfht_i'
-base: ['PA2_stretch_gri.srd', 'cfht_gri/base#base-i']
+base: ['PA2_stretch_gri.srd', 'cfht_gri/base#cfht-i']

--- a/specs/validate_drp/cfht_gri/PF1.yaml
+++ b/specs/validate_drp/cfht_gri/PF1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PF1_minimum_gri.cfht_g
 name: 'cfht_g'
-base: ['PF1_minimum_gri.srd', 'cfht_gri/base#base-g']
+base: ['PF1_minimum_gri.srd', 'cfht_gri/base#cfht-g']
 
 ---
 # validate_drp.PF1_minimum_gri.cfht_r
 name: 'cfht_r'
-base: ['PF1_minimum_gri.srd', 'cfht_gri/base#base-r']
+base: ['PF1_minimum_gri.srd', 'cfht_gri/base#cfht-r']
 
 ---
 # validate_drp.PF1_minimum_gri.cfht_i
 name: 'cfht_i'
-base: ['PF1_minimum_gri.srd', 'cfht_gri/base#base-i']
+base: ['PF1_minimum_gri.srd', 'cfht_gri/base#cfht-i']
 
 ---
 # validate_drp.PF1_design_gri.cfht_g
 name: 'cfht_g'
-base: ['PF1_design_gri.srd', 'cfht_gri/base#base-g']
+base: ['PF1_design_gri.srd', 'cfht_gri/base#cfht-g']
 
 ---
 # validate_drp.PF1_design_gri.cfht_r
 name: 'cfht_r'
-base: ['PF1_design_gri.srd', 'cfht_gri/base#base-r']
+base: ['PF1_design_gri.srd', 'cfht_gri/base#cfht-r']
 
 ---
 # validate_drp.PF1_design_gri.cfht_i
 name: 'cfht_i'
-base: ['PF1_design_gri.srd', 'cfht_gri/base#base-i']
+base: ['PF1_design_gri.srd', 'cfht_gri/base#cfht-i']
 
 ---
 # validate_drp.PF1_stretch_gri.cfht_g
 name: 'cfht_g'
-base: ['PF1_stretch_gri.srd', 'cfht_gri/base#base-g']
+base: ['PF1_stretch_gri.srd', 'cfht_gri/base#cfht-g']
 
 ---
 # validate_drp.PF1_stretch_gri.cfht_r
 name: 'cfht_r'
-base: ['PF1_stretch_gri.srd', 'cfht_gri/base#base-r']
+base: ['PF1_stretch_gri.srd', 'cfht_gri/base#cfht-r']
 
 ---
 # validate_drp.PF1_stretch_gri.cfht_i
 name: 'cfht_i'
-base: ['PF1_stretch_gri.srd', 'cfht_gri/base#base-i']
+base: ['PF1_stretch_gri.srd', 'cfht_gri/base#cfht-i']

--- a/specs/validate_drp/cfht_gri/base.yaml
+++ b/specs/validate_drp/cfht_gri/base.yaml
@@ -6,27 +6,28 @@
 
 ---
 # Select the CFHT test dataset
-id: 'base'
+id: 'cfht'
 metadata_query:
   instrument: 'CFHT'
   dataset_repo_url: 'https://github.com/lsst/validation_data_cfht.git'
+  dataset_name: 'validation_data_cfht'
   visits: [849375, 850587]
   ccds: [12, 13, 14, 21, 22, 23]
 
 ---
-id: 'base-g'
-base: '#base'
+id: 'cfht-g'
+base: '#cfht'
 metadata_query:
   filter_name: 'g'
 
 ---
-id: 'base-r'
-base: '#base'
+id: 'cfht-r'
+base: '#cfht'
 metadata_query:
   filter_name: 'r'
 
 ---
-id: 'base-i'
-base: '#base'
+id: 'cfht-i'
+base: '#cfht'
 metadata_query:
   filter_name: 'i'

--- a/specs/validate_drp/cfht_ugrizy/base.yaml
+++ b/specs/validate_drp/cfht_ugrizy/base.yaml
@@ -1,197 +1,141 @@
 ---
-name: 'cfht'
-base: 'AD1_design.srd'
+# Select the CFHT test dataset
+id: 'cfht'
 metadata_query:
   instrument: 'CFHT'
+  dataset_repo_url: 'https://github.com/lsst/validation_data_cfht.git'
+  dataset_name: 'validation_data_cfht'
+  visits: [849375, 850587]
+  ccds: [12, 13, 14, 21, 22, 23]
 
 ---
 name: 'cfht'
-base: 'AD1_minimum.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AD1_design.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AD1_stretch.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AD1_minimum.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AD2_design.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AD1_stretch.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AD2_minimum.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AD2_design.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AD2_stretch.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AD2_minimum.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AD3_design.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AD2_stretch.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AD3_minimum.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AD3_design.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AD3_stretch.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AD3_minimum.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AF1_design.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AD3_stretch.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AF1_minimum.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AF1_design.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AF1_stretch.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AF1_minimum.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AF2_design.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AF1_stretch.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AF2_minimum.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AF2_design.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AF2_stretch.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AF2_minimum.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AF3_design.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AF2_stretch.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AF3_minimum.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AF3_design.srd', '#cfht']
 
 ---
 name: 'cfht'
-base: 'AF3_stretch.srd'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AF3_minimum.srd', '#cfht']
+
+---
+name: 'cfht'
+base: ['AF3_stretch.srd', '#cfht']
 
 ---
 name: 'CFHT_design'
-base: 'AM1.design'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AM1.design', '#cfht']
 
 ---
 name: 'CFHT_minimum'
-base: 'AM1.minimum'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AM1.minimum', '#cfht']
 
 ---
 name: 'CFHT_stretch'
-base: 'AM1.stretch'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AM1.stretch', '#cfht']
 
 ---
 name: 'CFHT_design'
-base: 'AM2.design'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AM2.design', '#cfht']
 
 ---
 name: 'CFHT_minimum'
-base: 'AM2.minimum'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AM2.minimum', '#cfht']
 
 ---
 name: 'CFHT_stretch'
-base: 'AM2.stretch'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AM2.stretch', '#cfht']
 
 ---
 name: 'CFHT_design'
-base: 'AM3.design'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AM3.design', '#cfht']
 
 ---
 name: 'CFHT_minimum'
-base: 'AM3.minimum'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AM3.minimum', '#cfht']
 
 ---
 name: 'CFHT_stretch'
-base: 'AM3.stretch'
-metadata_query:
-  instrument: 'CFHT'
+base: ['AM3.stretch', '#cfht']
 
 ---
 name: 'CFHT_design'
-base: 'TE1.design'
-metadata_query:
-  instrument: 'CFHT'
+base: ['TE1.design', '#cfht']
 
 ---
 name: 'CFHT_minimum'
-base: 'TE1.minimum'
-metadata_query:
-  instrument: 'CFHT'
+base: ['TE1.minimum', '#cfht']
 
 ---
 name: 'CFHT_stretch'
-base: 'TE1.stretch'
-metadata_query:
-  instrument: 'CFHT'
+base: ['TE1.stretch', '#cfht']
 
 ---
 name: 'CFHT_design'
-base: 'TE2.design'
-metadata_query:
-  instrument: 'CFHT'
+base: ['TE2.design', '#cfht']
 
 ---
 name: 'CFHT_minimum'
-base: 'TE2.minimum'
-metadata_query:
-  instrument: 'CFHT'
+base: ['TE2.minimum', '#cfht']
 
 ---
 name: 'CFHT_stretch'
-base: 'TE2.stretch'
-metadata_query:
-  instrument: 'CFHT'
+base: ['TE2.stretch', '#cfht']

--- a/specs/validate_drp/cfht_uzy/PA1.yaml
+++ b/specs/validate_drp/cfht_uzy/PA1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA1.cfht_design_u
 name: 'cfht_design_u'
-base: ['PA1.design_uzy', 'cfht_uzy/base#base-u']
+base: ['PA1.design_uzy', 'cfht_uzy/base#cfht-u']
 
 ---
 # validate_drp.PA1.cfht_design_z
 name: 'cfht_design_z'
-base: ['PA1.design_uzy', 'cfht_uzy/base#base-z']
+base: ['PA1.design_uzy', 'cfht_uzy/base#cfht-z']
 
 ---
 # validate_drp.PA1.cfht_design_y
 name: 'cfht_design_y'
-base: ['PA1.design_uzy', 'cfht_uzy/base#base-y']
+base: ['PA1.design_uzy', 'cfht_uzy/base#cfht-y']
 
 ---
 # validate_drp.PA1.cfht_minimum_u
 name: 'cfht_minimum_u'
-base: ['PA1.minimum_uzy', 'cfht_uzy/base#base-u']
+base: ['PA1.minimum_uzy', 'cfht_uzy/base#cfht-u']
 
 ---
 # validate_drp.PA1.cfht_minimum_z
 name: 'cfht_minimum_z'
-base: ['PA1.minimum_uzy', 'cfht_uzy/base#base-z']
+base: ['PA1.minimum_uzy', 'cfht_uzy/base#cfht-z']
 
 ---
 # validate_drp.PA1.cfht_minimum_y
 name: 'cfht_minimum_y'
-base: ['PA1.minimum_uzy', 'cfht_uzy/base#base-y']
+base: ['PA1.minimum_uzy', 'cfht_uzy/base#cfht-y']
 
 ---
 # validate_drp.PA1.cfht_stretch_u
 name: 'cfht_stretch_u'
-base: ['PA1.stretch_uzy', 'cfht_uzy/base#base-u']
+base: ['PA1.stretch_uzy', 'cfht_uzy/base#cfht-u']
 
 ---
 # validate_drp.PA1.cfht_stretch_z
 name: 'cfht_stretch_z'
-base: ['PA1.stretch_uzy', 'cfht_uzy/base#base-z']
+base: ['PA1.stretch_uzy', 'cfht_uzy/base#cfht-z']
 
 ---
 # validate_drp.PA1.cfht_stretch_y
 name: 'cfht_stretch_y'
-base: ['PA1.stretch_uzy', 'cfht_uzy/base#base-y']
+base: ['PA1.stretch_uzy', 'cfht_uzy/base#cfht-y']

--- a/specs/validate_drp/cfht_uzy/PA2.yaml
+++ b/specs/validate_drp/cfht_uzy/PA2.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA2_minimum_uzy.cfht_u
 name: 'cfht_u'
-base: ['PA2_minimum_uzy.srd', 'cfht_uzy/base#base-u']
+base: ['PA2_minimum_uzy.srd', 'cfht_uzy/base#cfht-u']
 
 ---
 # validate_drp.PA2_minimum_uzy.cfht_z
 name: 'cfht_z'
-base: ['PA2_minimum_uzy.srd', 'cfht_uzy/base#base-z']
+base: ['PA2_minimum_uzy.srd', 'cfht_uzy/base#cfht-z']
 
 ---
 # validate_drp.PA2_minimum_uzy.cfht_y
 name: 'cfht_y'
-base: ['PA2_minimum_uzy.srd', 'cfht_uzy/base#base-y']
+base: ['PA2_minimum_uzy.srd', 'cfht_uzy/base#cfht-y']
 
 ---
 # validate_drp.PA2_design_uzy.cfht_u
 name: 'cfht_u'
-base: ['PA2_design_uzy.srd', 'cfht_uzy/base#base-u']
+base: ['PA2_design_uzy.srd', 'cfht_uzy/base#cfht-u']
 
 ---
 # validate_drp.PA2_design_uzy.cfht_z
 name: 'cfht_z'
-base: ['PA2_design_uzy.srd', 'cfht_uzy/base#base-z']
+base: ['PA2_design_uzy.srd', 'cfht_uzy/base#cfht-z']
 
 ---
 # validate_drp.PA2_design_uzy.cfht_y
 name: 'cfht_y'
-base: ['PA2_design_uzy.srd', 'cfht_uzy/base#base-y']
+base: ['PA2_design_uzy.srd', 'cfht_uzy/base#cfht-y']
 
 ---
 # validate_drp.PA2_stretch_uzy.cfht_u
 name: 'cfht_u'
-base: ['PA2_stretch_uzy.srd', 'cfht_uzy/base#base-u']
+base: ['PA2_stretch_uzy.srd', 'cfht_uzy/base#cfht-u']
 
 ---
 # validate_drp.PA2_stretch_uzy.cfht_z
 name: 'cfht_z'
-base: ['PA2_stretch_uzy.srd', 'cfht_uzy/base#base-z']
+base: ['PA2_stretch_uzy.srd', 'cfht_uzy/base#cfht-z']
 
 ---
 # validate_drp.PA2_stretch_uzy.cfht_y
 name: 'cfht_y'
-base: ['PA2_stretch_uzy.srd', 'cfht_uzy/base#base-y']
+base: ['PA2_stretch_uzy.srd', 'cfht_uzy/base#cfht-y']

--- a/specs/validate_drp/cfht_uzy/PF1.yaml
+++ b/specs/validate_drp/cfht_uzy/PF1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PF1_minimum_uzy.cfht_u
 name: 'cfht_u'
-base: ['PF1_minimum_uzy.srd', 'cfht_uzy/base#base-u']
+base: ['PF1_minimum_uzy.srd', 'cfht_uzy/base#cfht-u']
 
 ---
 # validate_drp.PF1_minimum_uzy.cfht_z
 name: 'cfht_z'
-base: ['PF1_minimum_uzy.srd', 'cfht_uzy/base#base-z']
+base: ['PF1_minimum_uzy.srd', 'cfht_uzy/base#cfht-z']
 
 ---
 # validate_drp.PF1_minimum_uzy.cfht_y
 name: 'cfht_y'
-base: ['PF1_minimum_uzy.srd', 'cfht_uzy/base#base-y']
+base: ['PF1_minimum_uzy.srd', 'cfht_uzy/base#cfht-y']
 
 ---
 # validate_drp.PF1_design_uzy.cfht_u
 name: 'cfht_u'
-base: ['PF1_design_uzy.srd', 'cfht_uzy/base#base-u']
+base: ['PF1_design_uzy.srd', 'cfht_uzy/base#cfht-u']
 
 ---
 # validate_drp.PF1_design_uzy.cfht_z
 name: 'cfht_z'
-base: ['PF1_design_uzy.srd', 'cfht_uzy/base#base-z']
+base: ['PF1_design_uzy.srd', 'cfht_uzy/base#cfht-z']
 
 ---
 # validate_drp.PF1_design_uzy.cfht_y
 name: 'cfht_y'
-base: ['PF1_design_uzy.srd', 'cfht_uzy/base#base-y']
+base: ['PF1_design_uzy.srd', 'cfht_uzy/base#cfht-y']
 
 ---
 # validate_drp.PF1_stretch_uzy.cfht_u
 name: 'cfht_u'
-base: ['PF1_stretch_uzy.srd', 'cfht_uzy/base#base-u']
+base: ['PF1_stretch_uzy.srd', 'cfht_uzy/base#cfht-u']
 
 ---
 # validate_drp.PF1_stretch_uzy.cfht_z
 name: 'cfht_z'
-base: ['PF1_stretch_uzy.srd', 'cfht_uzy/base#base-z']
+base: ['PF1_stretch_uzy.srd', 'cfht_uzy/base#cfht-z']
 
 ---
 # validate_drp.PF1_stretch_uzy.cfht_y
 name: 'cfht_y'
-base: ['PF1_stretch_uzy.srd', 'cfht_uzy/base#base-y']
+base: ['PF1_stretch_uzy.srd', 'cfht_uzy/base#cfht-y']

--- a/specs/validate_drp/cfht_uzy/base.yaml
+++ b/specs/validate_drp/cfht_uzy/base.yaml
@@ -6,27 +6,28 @@
 
 ---
 # Select the CFHT test dataset
-id: 'base'
+id: 'cfht'
 metadata_query:
   instrument: 'CFHT'
   dataset_repo_url: 'https://github.com/lsst/validation_data_cfht.git'
+  dataset_name: 'validation_data_cfht'
   visits: [849375, 850587]
   ccds: [12, 13, 14, 21, 22, 23]
 
 ---
-id: 'base-u'
-base: '#base'
+id: 'cfht-u'
+base: '#cfht'
 metadata_query:
   filter_name: 'u'
 
 ---
-id: 'base-z'
-base: '#base'
+id: 'cfht-z'
+base: '#cfht'
 metadata_query:
   filter_name: 'z'
 
 ---
-id: 'base-y'
-base: '#base'
+id: 'cfht-y'
+base: '#cfht'
 metadata_query:
   filter_name: 'y'

--- a/specs/validate_drp/decam_gri/PA1.yaml
+++ b/specs/validate_drp/decam_gri/PA1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA1.decam_design_g
 name: 'decam_design_g'
-base: ['PA1.design_gri', 'decam_gri/base#base-g']
+base: ['PA1.design_gri', 'decam_gri/base#decam-g']
 
 ---
 # validate_drp.PA1.decam_design_r
 name: 'decam_design_r'
-base: ['PA1.design_gri', 'decam_gri/base#base-r']
+base: ['PA1.design_gri', 'decam_gri/base#decam-r']
 
 ---
 # validate_drp.PA1.decam_design_i
 name: 'decam_design_i'
-base: ['PA1.design_gri', 'decam_gri/base#base-i']
+base: ['PA1.design_gri', 'decam_gri/base#decam-i']
 
 ---
 # validate_drp.PA1.decam_minimum_g
 name: 'decam_minimum_g'
-base: ['PA1.minimum_gri', 'decam_gri/base#base-g']
+base: ['PA1.minimum_gri', 'decam_gri/base#decam-g']
 
 ---
 # validate_drp.PA1.decam_minimum_r
 name: 'decam_minimum_r'
-base: ['PA1.minimum_gri', 'decam_gri/base#base-r']
+base: ['PA1.minimum_gri', 'decam_gri/base#decam-r']
 
 ---
 # validate_drp.PA1.decam_minimum_i
 name: 'decam_minimum_i'
-base: ['PA1.minimum_gri', 'decam_gri/base#base-i']
+base: ['PA1.minimum_gri', 'decam_gri/base#decam-i']
 
 ---
 # validate_drp.PA1.decam_stretch_g
 name: 'decam_stretch_g'
-base: ['PA1.stretch_gri', 'decam_gri/base#base-g']
+base: ['PA1.stretch_gri', 'decam_gri/base#decam-g']
 
 ---
 # validate_drp.PA1.decam_stretch_r
 name: 'decam_stretch_r'
-base: ['PA1.stretch_gri', 'decam_gri/base#base-r']
+base: ['PA1.stretch_gri', 'decam_gri/base#decam-r']
 
 ---
 # validate_drp.PA1.decam_stretch_i
 name: 'decam_stretch_i'
-base: ['PA1.stretch_gri', 'decam_gri/base#base-i']
+base: ['PA1.stretch_gri', 'decam_gri/base#decam-i']

--- a/specs/validate_drp/decam_gri/PA2.yaml
+++ b/specs/validate_drp/decam_gri/PA2.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA2_minimum_gri.decam_g
 name: 'decam_g'
-base: ['PA2_minimum_gri.srd', 'decam_gri/base#base-g']
+base: ['PA2_minimum_gri.srd', 'decam_gri/base#decam-g']
 
 ---
 # validate_drp.PA2_minimum_gri.decam_r
 name: 'decam_r'
-base: ['PA2_minimum_gri.srd', 'decam_gri/base#base-r']
+base: ['PA2_minimum_gri.srd', 'decam_gri/base#decam-r']
 
 ---
 # validate_drp.PA2_minimum_gri.decam_i
 name: 'decam_i'
-base: ['PA2_minimum_gri.srd', 'decam_gri/base#base-i']
+base: ['PA2_minimum_gri.srd', 'decam_gri/base#decam-i']
 
 ---
 # validate_drp.PA2_design_gri.decam_g
 name: 'decam_g'
-base: ['PA2_design_gri.srd', 'decam_gri/base#base-g']
+base: ['PA2_design_gri.srd', 'decam_gri/base#decam-g']
 
 ---
 # validate_drp.PA2_design_gri.decam_r
 name: 'decam_r'
-base: ['PA2_design_gri.srd', 'decam_gri/base#base-r']
+base: ['PA2_design_gri.srd', 'decam_gri/base#decam-r']
 
 ---
 # validate_drp.PA2_design_gri.decam_i
 name: 'decam_i'
-base: ['PA2_design_gri.srd', 'decam_gri/base#base-i']
+base: ['PA2_design_gri.srd', 'decam_gri/base#decam-i']
 
 ---
 # validate_drp.PA2_stretch_gri.decam_g
 name: 'decam_g'
-base: ['PA2_stretch_gri.srd', 'decam_gri/base#base-g']
+base: ['PA2_stretch_gri.srd', 'decam_gri/base#decam-g']
 
 ---
 # validate_drp.PA2_stretch_gri.decam_r
 name: 'decam_r'
-base: ['PA2_stretch_gri.srd', 'decam_gri/base#base-r']
+base: ['PA2_stretch_gri.srd', 'decam_gri/base#decam-r']
 
 ---
 # validate_drp.PA2_stretch_gri.decam_i
 name: 'decam_i'
-base: ['PA2_stretch_gri.srd', 'decam_gri/base#base-i']
+base: ['PA2_stretch_gri.srd', 'decam_gri/base#decam-i']

--- a/specs/validate_drp/decam_gri/PF1.yaml
+++ b/specs/validate_drp/decam_gri/PF1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PF1_minimum_gri.decam_g
 name: 'decam_g'
-base: ['PF1_minimum_gri.srd', 'decam_gri/base#base-g']
+base: ['PF1_minimum_gri.srd', 'decam_gri/base#decam-g']
 
 ---
 # validate_drp.PF1_minimum_gri.decam_r
 name: 'decam_r'
-base: ['PF1_minimum_gri.srd', 'decam_gri/base#base-r']
+base: ['PF1_minimum_gri.srd', 'decam_gri/base#decam-r']
 
 ---
 # validate_drp.PF1_minimum_gri.decam_i
 name: 'decam_i'
-base: ['PF1_minimum_gri.srd', 'decam_gri/base#base-i']
+base: ['PF1_minimum_gri.srd', 'decam_gri/base#decam-i']
 
 ---
 # validate_drp.PF1_design_gri.decam_g
 name: 'decam_g'
-base: ['PF1_design_gri.srd', 'decam_gri/base#base-g']
+base: ['PF1_design_gri.srd', 'decam_gri/base#decam-g']
 
 ---
 # validate_drp.PF1_design_gri.decam_r
 name: 'decam_r'
-base: ['PF1_design_gri.srd', 'decam_gri/base#base-r']
+base: ['PF1_design_gri.srd', 'decam_gri/base#decam-r']
 
 ---
 # validate_drp.PF1_design_gri.decam_i
 name: 'decam_i'
-base: ['PF1_design_gri.srd', 'decam_gri/base#base-i']
+base: ['PF1_design_gri.srd', 'decam_gri/base#decam-i']
 
 ---
 # validate_drp.PF1_stretch_gri.decam_g
 name: 'decam_g'
-base: ['PF1_stretch_gri.srd', 'decam_gri/base#base-g']
+base: ['PF1_stretch_gri.srd', 'decam_gri/base#decam-g']
 
 ---
 # validate_drp.PF1_stretch_gri.decam_r
 name: 'decam_r'
-base: ['PF1_stretch_gri.srd', 'decam_gri/base#base-r']
+base: ['PF1_stretch_gri.srd', 'decam_gri/base#decam-r']
 
 ---
 # validate_drp.PF1_stretch_gri.decam_i
 name: 'decam_i'
-base: ['PF1_stretch_gri.srd', 'decam_gri/base#base-i']
+base: ['PF1_stretch_gri.srd', 'decam_gri/base#decam-i']

--- a/specs/validate_drp/decam_gri/base.yaml
+++ b/specs/validate_drp/decam_gri/base.yaml
@@ -4,26 +4,28 @@
 # in the g, r, or i bands.
 
 ---
-# Select the CFHT test dataset
-id: 'base'
+# Select the DECam test dataset
+id: 'decam'
 metadata_query:
   instrument: 'DECAM'
   dataset_repo_url: 'https://github.com/lsst/validation_data_decam.git'
+  dataset_name: 'validation_data_decam'
+  # May need to add specific visits and ccds for the test dataset
 
 ---
-id: 'base-g'
-base: '#base'
+id: 'decam-g'
+base: '#decam'
 metadata_query:
   filter_name: 'g'
 
 ---
-id: 'base-r'
-base: '#base'
+id: 'decam-r'
+base: '#decam'
 metadata_query:
   filter_name: 'r'
 
 ---
-id: 'base-i'
-base: '#base'
+id: 'decam-i'
+base: '#decam'
 metadata_query:
   filter_name: 'i'

--- a/specs/validate_drp/decam_ugrizy/base.yaml
+++ b/specs/validate_drp/decam_ugrizy/base.yaml
@@ -1,197 +1,140 @@
 ---
-name: 'decam'
-base: 'AD1_design.srd'
+# Select the DECam test dataset
+id: 'decam'
 metadata_query:
   instrument: 'DECAM'
+  dataset_repo_url: 'https://github.com/lsst/validation_data_decam.git'
+  dataset_name: 'validation_data_decam'
+  # May need to add specific visits and ccds for the test dataset
 
 ---
 name: 'decam'
-base: 'AD1_minimum.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AD1_design.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AD1_stretch.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AD1_minimum.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AD2_design.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AD1_stretch.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AD2_minimum.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AD2_design.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AD2_stretch.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AD2_minimum.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AD3_design.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AD2_stretch.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AD3_minimum.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AD3_design.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AD3_stretch.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AD3_minimum.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AF1_design.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AD3_stretch.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AF1_minimum.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AF1_design.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AF1_stretch.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AF1_minimum.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AF2_design.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AF1_stretch.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AF2_minimum.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AF2_design.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AF2_stretch.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AF2_minimum.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AF3_design.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AF2_stretch.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AF3_minimum.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AF3_design.srd', '#decam']
 
 ---
 name: 'decam'
-base: 'AF3_stretch.srd'
-metadata_query:
-  instrument: 'DECAM'
+base: ['AF3_minimum.srd', '#decam']
 
 ---
-name: 'decam_design'
-base: 'AM1.design'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['AF3_stretch.srd', '#decam']
 
 ---
-name: 'decam_minimum'
-base: 'AM1.minimum'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['AM1.design', '#decam']
 
 ---
-name: 'decam_stretch'
-base: 'AM1.stretch'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['AM1.minimum', '#decam']
 
 ---
-name: 'decam_design'
-base: 'AM2.design'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['AM1.stretch', '#decam']
 
 ---
-name: 'decam_minimum'
-base: 'AM2.minimum'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['AM2.design', '#decam']
 
 ---
-name: 'decam_stretch'
-base: 'AM2.stretch'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['AM2.minimum', '#decam']
 
 ---
-name: 'decam_design'
-base: 'AM3.design'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['AM2.stretch', '#decam']
 
 ---
-name: 'decam_minimum'
-base: 'AM3.minimum'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['AM3.design', '#decam']
 
 ---
-name: 'decam_stretch'
-base: 'AM3.stretch'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['AM3.minimum', '#decam']
 
 ---
-name: 'decam_design'
-base: 'TE1.design'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['AM3.stretch', '#decam']
 
 ---
-name: 'decam_minimum'
-base: 'TE1.minimum'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['TE1.design', '#decam']
 
 ---
-name: 'decam_stretch'
-base: 'TE1.stretch'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['TE1.minimum', '#decam']
 
 ---
-name: 'decam_design'
-base: 'TE2.design'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['TE1.stretch', '#decam']
 
 ---
-name: 'decam_minimum'
-base: 'TE2.minimum'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['TE2.design', '#decam']
 
 ---
-name: 'decam_stretch'
-base: 'TE2.stretch'
-metadata_query:
-  instrument: 'DECAM'
+name: 'decam'
+base: ['TE2.minimum', '#decam']
+
+---
+name: 'decam'
+base: ['TE2.stretch', '#decam']

--- a/specs/validate_drp/decam_uzy/PA1.yaml
+++ b/specs/validate_drp/decam_uzy/PA1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA1.decam_design_u
 name: 'decam_design_u'
-base: ['PA1.design_uzy', 'decam_uzy/base#base-u']
+base: ['PA1.design_uzy', 'decam_uzy/base#decam-u']
 
 ---
 # validate_drp.PA1.decam_design_z
 name: 'decam_design_z'
-base: ['PA1.design_uzy', 'decam_uzy/base#base-z']
+base: ['PA1.design_uzy', 'decam_uzy/base#decam-z']
 
 ---
 # validate_drp.PA1.decam_design_y
 name: 'decam_design_y'
-base: ['PA1.design_uzy', 'decam_uzy/base#base-y']
+base: ['PA1.design_uzy', 'decam_uzy/base#decam-y']
 
 ---
 # validate_drp.PA1.decam_minimum_u
 name: 'decam_minimum_u'
-base: ['PA1.minimum_uzy', 'decam_uzy/base#base-u']
+base: ['PA1.minimum_uzy', 'decam_uzy/base#decam-u']
 
 ---
 # validate_drp.PA1.decam_minimum_z
 name: 'decam_minimum_z'
-base: ['PA1.minimum_uzy', 'decam_uzy/base#base-z']
+base: ['PA1.minimum_uzy', 'decam_uzy/base#decam-z']
 
 ---
 # validate_drp.PA1.decam_minimum_y
 name: 'decam_minimum_y'
-base: ['PA1.minimum_uzy', 'decam_uzy/base#base-y']
+base: ['PA1.minimum_uzy', 'decam_uzy/base#decam-y']
 
 ---
 # validate_drp.PA1.decam_stretch_u
 name: 'decam_stretch_u'
-base: ['PA1.stretch_uzy', 'decam_uzy/base#base-u']
+base: ['PA1.stretch_uzy', 'decam_uzy/base#decam-u']
 
 ---
 # validate_drp.PA1.decam_stretch_z
 name: 'decam_stretch_z'
-base: ['PA1.stretch_uzy', 'decam_uzy/base#base-z']
+base: ['PA1.stretch_uzy', 'decam_uzy/base#decam-z']
 
 ---
 # validate_drp.PA1.decam_stretch_y
 name: 'decam_stretch_y'
-base: ['PA1.stretch_uzy', 'decam_uzy/base#base-y']
+base: ['PA1.stretch_uzy', 'decam_uzy/base#decam-y']

--- a/specs/validate_drp/decam_uzy/PA2.yaml
+++ b/specs/validate_drp/decam_uzy/PA2.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA2_minimum_uzy.decam_u
 name: 'decam_u'
-base: ['PA2_minimum_uzy.srd', 'decam_uzy/base#base-u']
+base: ['PA2_minimum_uzy.srd', 'decam_uzy/base#decam-u']
 
 ---
 # validate_drp.PA2_minimum_uzy.decam_z
 name: 'decam_z'
-base: ['PA2_minimum_uzy.srd', 'decam_uzy/base#base-z']
+base: ['PA2_minimum_uzy.srd', 'decam_uzy/base#decam-z']
 
 ---
 # validate_drp.PA2_minimum_uzy.decam_y
 name: 'decam_y'
-base: ['PA2_minimum_uzy.srd', 'decam_uzy/base#base-y']
+base: ['PA2_minimum_uzy.srd', 'decam_uzy/base#decam-y']
 
 ---
 # validate_drp.PA2_design_uzy.decam_u
 name: 'decam_u'
-base: ['PA2_design_uzy.srd', 'decam_uzy/base#base-u']
+base: ['PA2_design_uzy.srd', 'decam_uzy/base#decam-u']
 
 ---
 # validate_drp.PA2_design_uzy.decam_z
 name: 'decam_z'
-base: ['PA2_design_uzy.srd', 'decam_uzy/base#base-z']
+base: ['PA2_design_uzy.srd', 'decam_uzy/base#decam-z']
 
 ---
 # validate_drp.PA2_design_uzy.decam_y
 name: 'decam_y'
-base: ['PA2_design_uzy.srd', 'decam_uzy/base#base-y']
+base: ['PA2_design_uzy.srd', 'decam_uzy/base#decam-y']
 
 ---
 # validate_drp.PA2_stretch_uzy.decam_u
 name: 'decam_u'
-base: ['PA2_stretch_uzy.srd', 'decam_uzy/base#base-u']
+base: ['PA2_stretch_uzy.srd', 'decam_uzy/base#decam-u']
 
 ---
 # validate_drp.PA2_stretch_uzy.decam_z
 name: 'decam_z'
-base: ['PA2_stretch_uzy.srd', 'decam_uzy/base#base-z']
+base: ['PA2_stretch_uzy.srd', 'decam_uzy/base#decam-z']
 
 ---
 # validate_drp.PA2_stretch_uzy.decam_y
 name: 'decam_y'
-base: ['PA2_stretch_uzy.srd', 'decam_uzy/base#base-y']
+base: ['PA2_stretch_uzy.srd', 'decam_uzy/base#decam-y']

--- a/specs/validate_drp/decam_uzy/PF1.yaml
+++ b/specs/validate_drp/decam_uzy/PF1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PF1_minimum_uzy.decam_u
 name: 'decam_u'
-base: ['PF1_minimum_uzy.srd', 'decam_uzy/base#base-u']
+base: ['PF1_minimum_uzy.srd', 'decam_uzy/base#decam-u']
 
 ---
 # validate_drp.PF1_minimum_uzy.decam_z
 name: 'decam_z'
-base: ['PF1_minimum_uzy.srd', 'decam_uzy/base#base-z']
+base: ['PF1_minimum_uzy.srd', 'decam_uzy/base#decam-z']
 
 ---
 # validate_drp.PF1_minimum_uzy.decam_y
 name: 'decam_y'
-base: ['PF1_minimum_uzy.srd', 'decam_uzy/base#base-y']
+base: ['PF1_minimum_uzy.srd', 'decam_uzy/base#decam-y']
 
 ---
 # validate_drp.PF1_design_uzy.decam_u
 name: 'decam_u'
-base: ['PF1_design_uzy.srd', 'decam_uzy/base#base-u']
+base: ['PF1_design_uzy.srd', 'decam_uzy/base#decam-u']
 
 ---
 # validate_drp.PF1_design_uzy.decam_z
 name: 'decam_z'
-base: ['PF1_design_uzy.srd', 'decam_uzy/base#base-z']
+base: ['PF1_design_uzy.srd', 'decam_uzy/base#decam-z']
 
 ---
 # validate_drp.PF1_design_uzy.decam_y
 name: 'decam_y'
-base: ['PF1_design_uzy.srd', 'decam_uzy/base#base-y']
+base: ['PF1_design_uzy.srd', 'decam_uzy/base#decam-y']
 
 ---
 # validate_drp.PF1_stretch_uzy.decam_u
 name: 'decam_u'
-base: ['PF1_stretch_uzy.srd', 'decam_uzy/base#base-u']
+base: ['PF1_stretch_uzy.srd', 'decam_uzy/base#decam-u']
 
 ---
 # validate_drp.PF1_stretch_uzy.decam_z
 name: 'decam_z'
-base: ['PF1_stretch_uzy.srd', 'decam_uzy/base#base-z']
+base: ['PF1_stretch_uzy.srd', 'decam_uzy/base#decam-z']
 
 ---
 # validate_drp.PF1_stretch_uzy.decam_y
 name: 'decam_y'
-base: ['PF1_stretch_uzy.srd', 'decam_uzy/base#base-y']
+base: ['PF1_stretch_uzy.srd', 'decam_uzy/base#decam-y']

--- a/specs/validate_drp/decam_uzy/base.yaml
+++ b/specs/validate_drp/decam_uzy/base.yaml
@@ -5,25 +5,27 @@
 
 ---
 # Select the CFHT test dataset
-id: 'base'
+id: 'decam'
 metadata_query:
   instrument: 'DECAM'
   dataset_repo_url: 'https://github.com/lsst/validation_data_decam.git'
+  dataset_name: 'validation_data_decam'
+  # May need to add specific visits and ccds for the test dataset
 
 ---
-id: 'base-u'
-base: '#base'
+id: 'decam-u'
+base: '#decam'
 metadata_query:
   filter_name: 'u'
 
 ---
-id: 'base-z'
-base: '#base'
+id: 'decam-z'
+base: '#decam'
 metadata_query:
   filter_name: 'z'
 
 ---
-id: 'base-y'
-base: '#base'
+id: 'decam-y'
+base: '#decam'
 metadata_query:
   filter_name: 'y'

--- a/specs/validate_drp/hsc_gri/PA1.yaml
+++ b/specs/validate_drp/hsc_gri/PA1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA1.hsc_design_g
 name: 'hsc_design_g'
-base: ['PA1.design_gri', 'hsc_gri/base#base-g']
+base: ['PA1.design_gri', 'hsc_gri/base#hsc-g']
 
 ---
 # validate_drp.PA1.hsc_design_r
 name: 'hsc_design_r'
-base: ['PA1.design_gri', 'hsc_gri/base#base-r']
+base: ['PA1.design_gri', 'hsc_gri/base#hsc-r']
 
 ---
 # validate_drp.PA1.hsc_design_i
 name: 'hsc_design_i'
-base: ['PA1.design_gri', 'hsc_gri/base#base-i']
+base: ['PA1.design_gri', 'hsc_gri/base#hsc-i']
 
 ---
 # validate_drp.PA1.hsc_minimum_g
 name: 'hsc_minimum_g'
-base: ['PA1.minimum_gri', 'hsc_gri/base#base-g']
+base: ['PA1.minimum_gri', 'hsc_gri/base#hsc-g']
 
 ---
 # validate_drp.PA1.hsc_minimum_r
 name: 'hsc_minimum_r'
-base: ['PA1.minimum_gri', 'hsc_gri/base#base-r']
+base: ['PA1.minimum_gri', 'hsc_gri/base#hsc-r']
 
 ---
 # validate_drp.PA1.hsc_minimum_i
 name: 'hsc_minimum_i'
-base: ['PA1.minimum_gri', 'hsc_gri/base#base-i']
+base: ['PA1.minimum_gri', 'hsc_gri/base#hsc-i']
 
 ---
 # validate_drp.PA1.hsc_stretch_g
 name: 'hsc_stretch_g'
-base: ['PA1.stretch_gri', 'hsc_gri/base#base-g']
+base: ['PA1.stretch_gri', 'hsc_gri/base#hsc-g']
 
 ---
 # validate_drp.PA1.hsc_stretch_r
 name: 'hsc_stretch_r'
-base: ['PA1.stretch_gri', 'hsc_gri/base#base-r']
+base: ['PA1.stretch_gri', 'hsc_gri/base#hsc-r']
 
 ---
 # validate_drp.PA1.hsc_stretch_i
 name: 'hsc_stretch_i'
-base: ['PA1.stretch_gri', 'hsc_gri/base#base-i']
+base: ['PA1.stretch_gri', 'hsc_gri/base#hsc-i']

--- a/specs/validate_drp/hsc_gri/PA2.yaml
+++ b/specs/validate_drp/hsc_gri/PA2.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA2_minimum_gri.hsc_g
 name: 'hsc_g'
-base: ['PA2_minimum_gri.srd', 'hsc_gri/base#base-g']
+base: ['PA2_minimum_gri.srd', 'hsc_gri/base#hsc-g']
 
 ---
 # validate_drp.PA2_minimum_gri.hsc_r
 name: 'hsc_r'
-base: ['PA2_minimum_gri.srd', 'hsc_gri/base#base-r']
+base: ['PA2_minimum_gri.srd', 'hsc_gri/base#hsc-r']
 
 ---
 # validate_drp.PA2_minimum_gri.hsc_i
 name: 'hsc_i'
-base: ['PA2_minimum_gri.srd', 'hsc_gri/base#base-i']
+base: ['PA2_minimum_gri.srd', 'hsc_gri/base#hsc-i']
 
 ---
 # validate_drp.PA2_design_gri.hsc_g
 name: 'hsc_g'
-base: ['PA2_design_gri.srd', 'hsc_gri/base#base-g']
+base: ['PA2_design_gri.srd', 'hsc_gri/base#hsc-g']
 
 ---
 # validate_drp.PA2_design_gri.hsc_r
 name: 'hsc_r'
-base: ['PA2_design_gri.srd', 'hsc_gri/base#base-r']
+base: ['PA2_design_gri.srd', 'hsc_gri/base#hsc-r']
 
 ---
 # validate_drp.PA2_design_gri.hsc_i
 name: 'hsc_i'
-base: ['PA2_design_gri.srd', 'hsc_gri/base#base-i']
+base: ['PA2_design_gri.srd', 'hsc_gri/base#hsc-i']
 
 ---
 # validate_drp.PA2_stretch_gri.hsc_g
 name: 'hsc_g'
-base: ['PA2_stretch_gri.srd', 'hsc_gri/base#base-g']
+base: ['PA2_stretch_gri.srd', 'hsc_gri/base#hsc-g']
 
 ---
 # validate_drp.PA2_stretch_gri.hsc_r
 name: 'hsc_r'
-base: ['PA2_stretch_gri.srd', 'hsc_gri/base#base-r']
+base: ['PA2_stretch_gri.srd', 'hsc_gri/base#hsc-r']
 
 ---
 # validate_drp.PA2_stretch_gri.hsc_i
 name: 'hsc_i'
-base: ['PA2_stretch_gri.srd', 'hsc_gri/base#base-i']
+base: ['PA2_stretch_gri.srd', 'hsc_gri/base#hsc-i']

--- a/specs/validate_drp/hsc_gri/PF1.yaml
+++ b/specs/validate_drp/hsc_gri/PF1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PF1_minimum_gri.hsc_g
 name: 'hsc_g'
-base: ['PF1_minimum_gri.srd', 'hsc_gri/base#base-g']
+base: ['PF1_minimum_gri.srd', 'hsc_gri/base#hsc-g']
 
 ---
 # validate_drp.PF1_minimum_gri.hsc_r
 name: 'hsc_r'
-base: ['PF1_minimum_gri.srd', 'hsc_gri/base#base-r']
+base: ['PF1_minimum_gri.srd', 'hsc_gri/base#hsc-r']
 
 ---
 # validate_drp.PF1_minimum_gri.hsc_i
 name: 'hsc_i'
-base: ['PF1_minimum_gri.srd', 'hsc_gri/base#base-i']
+base: ['PF1_minimum_gri.srd', 'hsc_gri/base#hsc-i']
 
 ---
 # validate_drp.PF1_design_gri.hsc_g
 name: 'hsc_g'
-base: ['PF1_design_gri.srd', 'hsc_gri/base#base-g']
+base: ['PF1_design_gri.srd', 'hsc_gri/base#hsc-g']
 
 ---
 # validate_drp.PF1_design_gri.hsc_r
 name: 'hsc_r'
-base: ['PF1_design_gri.srd', 'hsc_gri/base#base-r']
+base: ['PF1_design_gri.srd', 'hsc_gri/base#hsc-r']
 
 ---
 # validate_drp.PF1_design_gri.hsc_i
 name: 'hsc_i'
-base: ['PF1_design_gri.srd', 'hsc_gri/base#base-i']
+base: ['PF1_design_gri.srd', 'hsc_gri/base#hsc-i']
 
 ---
 # validate_drp.PF1_stretch_gri.hsc_g
 name: 'hsc_g'
-base: ['PF1_stretch_gri.srd', 'hsc_gri/base#base-g']
+base: ['PF1_stretch_gri.srd', 'hsc_gri/base#hsc-g']
 
 ---
 # validate_drp.PF1_stretch_gri.hsc_r
 name: 'hsc_r'
-base: ['PF1_stretch_gri.srd', 'hsc_gri/base#base-r']
+base: ['PF1_stretch_gri.srd', 'hsc_gri/base#hsc-r']
 
 ---
 # validate_drp.PF1_stretch_gri.hsc_i
 name: 'hsc_i'
-base: ['PF1_stretch_gri.srd', 'hsc_gri/base#base-i']
+base: ['PF1_stretch_gri.srd', 'hsc_gri/base#hsc-i']

--- a/specs/validate_drp/hsc_gri/base.yaml
+++ b/specs/validate_drp/hsc_gri/base.yaml
@@ -2,26 +2,27 @@
 
 ---
 # Select the HSC test dataset
-id: 'base'
+id: 'hsc'
 metadata_query:
   instrument: 'HSC'
   dataset_repo_url: 'https://github.com/lsst/validation_data_hsc.git'
+  dataset_name: 'validation_data_hsc'
   # May need to add specific visits and ccds for the test dataset
 
 ---
-id: 'base-g'
-base: '#base'
+id: 'hsc-g'
+base: '#hsc'
 metadata_query:
   filter_name: 'HSC-G'
 
 ---
-id: 'base-r'
-base: '#base'
+id: 'hsc-r'
+base: '#hsc'
 metadata_query:
   filter_name: 'HSC-R'
 
 ---
-id: 'base-i'
-base: '#base'
+id: 'hsc-i'
+base: '#hsc'
 metadata_query:
   filter_name: 'HSC-I'

--- a/specs/validate_drp/hsc_ugrizy/base.yaml
+++ b/specs/validate_drp/hsc_ugrizy/base.yaml
@@ -1,197 +1,140 @@
 ---
-name: 'hsc'
-base: 'AD1_design.srd'
+# Select the HSC test dataset
+id: 'hsc'
 metadata_query:
   instrument: 'HSC'
+  dataset_repo_url: 'https://github.com/lsst/validation_data_hsc.git'
+  dataset_name: 'validation_data_hsc'
+  # May need to add specific visits and ccds for the test dataset
 
 ---
 name: 'hsc'
-base: 'AD1_minimum.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AD1_design.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AD1_stretch.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AD1_minimum.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AD2_design.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AD1_stretch.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AD2_minimum.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AD2_design.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AD2_stretch.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AD2_minimum.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AD3_design.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AD2_stretch.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AD3_minimum.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AD3_design.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AD3_stretch.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AD3_minimum.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AF1_design.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AD3_stretch.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AF1_minimum.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AF1_design.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AF1_stretch.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AF1_minimum.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AF2_design.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AF1_stretch.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AF2_minimum.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AF2_design.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AF2_stretch.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AF2_minimum.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AF3_design.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AF2_stretch.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AF3_minimum.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AF3_design.srd', '#hsc']
 
 ---
 name: 'hsc'
-base: 'AF3_stretch.srd'
-metadata_query:
-  instrument: 'HSC'
+base: ['AF3_minimum.srd', '#hsc']
+
+---
+name: 'hsc'
+base: ['AF3_stretch.srd', '#hsc']
 
 ---
 name: 'hsc_design'
-base: 'AM1.design'
-metadata_query:
-  instrument: 'HSC'
+base: ['AM1.design', '#hsc']
 
 ---
 name: 'hsc_minimum'
-base: 'AM1.minimum'
-metadata_query:
-  instrument: 'HSC'
+base: ['AM1.minimum', '#hsc']
 
 ---
 name: 'hsc_stretch'
-base: 'AM1.stretch'
-metadata_query:
-  instrument: 'HSC'
+base: ['AM1.stretch', '#hsc']
 
 ---
 name: 'hsc_design'
-base: 'AM2.design'
-metadata_query:
-  instrument: 'HSC'
+base: ['AM2.design', '#hsc']
 
 ---
 name: 'hsc_minimum'
-base: 'AM2.minimum'
-metadata_query:
-  instrument: 'HSC'
+base: ['AM2.minimum', '#hsc']
 
 ---
 name: 'hsc_stretch'
-base: 'AM2.stretch'
-metadata_query:
-  instrument: 'HSC'
+base: ['AM2.stretch', '#hsc']
 
 ---
 name: 'hsc_design'
-base: 'AM3.design'
-metadata_query:
-  instrument: 'HSC'
+base: ['AM3.design', '#hsc']
 
 ---
 name: 'hsc_minimum'
-base: 'AM3.minimum'
-metadata_query:
-  instrument: 'HSC'
+base: ['AM3.minimum', '#hsc']
 
 ---
 name: 'hsc_stretch'
-base: 'AM3.stretch'
-metadata_query:
-  instrument: 'HSC'
+base: ['AM3.stretch', '#hsc']
 
 ---
 name: 'hsc_design'
-base: 'TE1.design'
-metadata_query:
-  instrument: 'HSC'
+base: ['TE1.design', '#hsc']
 
 ---
 name: 'hsc_minimum'
-base: 'TE1.minimum'
-metadata_query:
-  instrument: 'HSC'
+base: ['TE1.minimum', '#hsc']
 
 ---
 name: 'hsc_stretch'
-base: 'TE1.stretch'
-metadata_query:
-  instrument: 'HSC'
+base: ['TE1.stretch', '#hsc']
 
 ---
 name: 'hsc_design'
-base: 'TE2.design'
-metadata_query:
-  instrument: 'HSC'
+base: ['TE2.design', '#hsc']
 
 ---
 name: 'hsc_minimum'
-base: 'TE2.minimum'
-metadata_query:
-  instrument: 'HSC'
+base: ['TE2.minimum', '#hsc']
 
 ---
 name: 'hsc_stretch'
-base: 'TE2.stretch'
-metadata_query:
-  instrument: 'HSC'
+base: ['TE2.stretch', '#hsc']

--- a/specs/validate_drp/hsc_uzy/PA1.yaml
+++ b/specs/validate_drp/hsc_uzy/PA1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA1.hsc_design_u
 name: 'hsc_design_u'
-base: ['PA1.design_uzy', 'hsc_uzy/base#base-u']
+base: ['PA1.design_uzy', 'hsc_uzy/base#hsc-u']
 
 ---
 # validate_drp.PA1.hsc_design_z
 name: 'hsc_design_z'
-base: ['PA1.design_uzy', 'hsc_uzy/base#base-z']
+base: ['PA1.design_uzy', 'hsc_uzy/base#hsc-z']
 
 ---
 # validate_drp.PA1.hsc_design_y
 name: 'hsc_design_y'
-base: ['PA1.design_uzy', 'hsc_uzy/base#base-y']
+base: ['PA1.design_uzy', 'hsc_uzy/base#hsc-y']
 
 ---
 # validate_drp.PA1.hsc_minimum_u
 name: 'hsc_minimum_u'
-base: ['PA1.minimum_uzy', 'hsc_uzy/base#base-u']
+base: ['PA1.minimum_uzy', 'hsc_uzy/base#hsc-u']
 
 ---
 # validate_drp.PA1.hsc_minimum_z
 name: 'hsc_minimum_z'
-base: ['PA1.minimum_uzy', 'hsc_uzy/base#base-z']
+base: ['PA1.minimum_uzy', 'hsc_uzy/base#hsc-z']
 
 ---
 # validate_drp.PA1.hsc_minimum_y
 name: 'hsc_minimum_y'
-base: ['PA1.minimum_uzy', 'hsc_uzy/base#base-y']
+base: ['PA1.minimum_uzy', 'hsc_uzy/base#hsc-y']
 
 ---
 # validate_drp.PA1.hsc_stretch_u
 name: 'hsc_stretch_u'
-base: ['PA1.stretch_uzy', 'hsc_uzy/base#base-u']
+base: ['PA1.stretch_uzy', 'hsc_uzy/base#hsc-u']
 
 ---
 # validate_drp.PA1.hsc_stretch_z
 name: 'hsc_stretch_z'
-base: ['PA1.stretch_uzy', 'hsc_uzy/base#base-z']
+base: ['PA1.stretch_uzy', 'hsc_uzy/base#hsc-z']
 
 ---
 # validate_drp.PA1.hsc_stretch_y
 name: 'hsc_stretch_y'
-base: ['PA1.stretch_uzy', 'hsc_uzy/base#base-y']
+base: ['PA1.stretch_uzy', 'hsc_uzy/base#hsc-y']

--- a/specs/validate_drp/hsc_uzy/PA2.yaml
+++ b/specs/validate_drp/hsc_uzy/PA2.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PA2_design_uzy.hsc_u
 name: 'hsc_design_u'
-base: ['PA2_design_uzy.srd', 'hsc_uzy/base#base-u']
+base: ['PA2_design_uzy.srd', 'hsc_uzy/base#hsc-u']
 
 ---
 # validate_drp.PA2_design_uzy.hsc_z
 name: 'hsc_design_z'
-base: ['PA2_design_uzy.srd', 'hsc_uzy/base#base-z']
+base: ['PA2_design_uzy.srd', 'hsc_uzy/base#hsc-z']
 
 ---
 # validate_drp.PA2_design_uzy.hsc_y
 name: 'hsc_design_y'
-base: ['PA2_design_uzy.srd', 'hsc_uzy/base#base-y']
+base: ['PA2_design_uzy.srd', 'hsc_uzy/base#hsc-y']
 
 ---
 # validate_drp.PA2_minimum_uzy.hsc_u
 name: 'hsc_minimum_u'
-base: ['PA2_minimum_uzy.srd', 'hsc_uzy/base#base-u']
+base: ['PA2_minimum_uzy.srd', 'hsc_uzy/base#hsc-u']
 
 ---
 # validate_drp.PA2_minimum_uzy.hsc_z
 name: 'hsc_minimum_z'
-base: ['PA2_minimum_uzy.srd', 'hsc_uzy/base#base-z']
+base: ['PA2_minimum_uzy.srd', 'hsc_uzy/base#hsc-z']
 
 ---
 # validate_drp.PA2_minimum_uzy.hsc_y
 name: 'hsc_minimum_y'
-base: ['PA2_minimum_uzy.srd', 'hsc_uzy/base#base-y']
+base: ['PA2_minimum_uzy.srd', 'hsc_uzy/base#hsc-y']
 
 ---
 # validate_drp.PA2_stretch_uzy.hsc_u
 name: 'hsc_stretch_u'
-base: ['PA2_stretch_uzy.srd', 'hsc_uzy/base#base-u']
+base: ['PA2_stretch_uzy.srd', 'hsc_uzy/base#hsc-u']
 
 ---
 # validate_drp.PA2_stretch_uzy.hsc_z
 name: 'hsc_stretch_z'
-base: ['PA2_stretch_uzy.srd', 'hsc_uzy/base#base-z']
+base: ['PA2_stretch_uzy.srd', 'hsc_uzy/base#hsc-z']
 
 ---
 # validate_drp.PA2_stretch_uzy.hsc_y
 name: 'hsc_stretch_y'
-base: ['PA2_stretch_uzy.srd', 'hsc_uzy/base#base-y']
+base: ['PA2_stretch_uzy.srd', 'hsc_uzy/base#hsc-y']

--- a/specs/validate_drp/hsc_uzy/PF1.yaml
+++ b/specs/validate_drp/hsc_uzy/PF1.yaml
@@ -1,44 +1,44 @@
 ---
 # validate_drp.PF1_design_uzy.hsc_u
 name: 'hsc_design_u'
-base: ['PF1_design_uzy.srd', 'hsc_uzy/base#base-u']
+base: ['PF1_design_uzy.srd', 'hsc_uzy/base#hsc-u']
 
 ---
 # validate_drp.PF1_design_uzy.hsc_z
 name: 'hsc_design_z'
-base: ['PF1_design_uzy.srd', 'hsc_uzy/base#base-z']
+base: ['PF1_design_uzy.srd', 'hsc_uzy/base#hsc-z']
 
 ---
 # validate_drp.PF1_design_uzy.hsc_y
 name: 'hsc_design_y'
-base: ['PF1_design_uzy.srd', 'hsc_uzy/base#base-y']
+base: ['PF1_design_uzy.srd', 'hsc_uzy/base#hsc-y']
 
 ---
 # validate_drp.PF1_minimum_uzy.hsc_u
 name: 'hsc_minimum_u'
-base: ['PF1_minimum_uzy.srd', 'hsc_uzy/base#base-u']
+base: ['PF1_minimum_uzy.srd', 'hsc_uzy/base#hsc-u']
 
 ---
 # validate_drp.PF1_minimum_uzy.hsc_z
 name: 'hsc_minimum_z'
-base: ['PF1_minimum_uzy.srd', 'hsc_uzy/base#base-z']
+base: ['PF1_minimum_uzy.srd', 'hsc_uzy/base#hsc-z']
 
 ---
 # validate_drp.PF1_minimum_uzy.hsc_y
 name: 'hsc_minimum_y'
-base: ['PF1_minimum_uzy.srd', 'hsc_uzy/base#base-y']
+base: ['PF1_minimum_uzy.srd', 'hsc_uzy/base#hsc-y']
 
 ---
 # validate_drp.PF1_stretch_uzy.hsc_u
 name: 'hsc_stretch_u'
-base: ['PF1_stretch_uzy.srd', 'hsc_uzy/base#base-u']
+base: ['PF1_stretch_uzy.srd', 'hsc_uzy/base#hsc-u']
 
 ---
 # validate_drp.PF1_stretch_uzy.hsc_z
 name: 'hsc_stretch_z'
-base: ['PF1_stretch_uzy.srd', 'hsc_uzy/base#base-z']
+base: ['PF1_stretch_uzy.srd', 'hsc_uzy/base#hsc-z']
 
 ---
 # validate_drp.PF1_stretch_uzy.hsc_y
 name: 'hsc_stretch_y'
-base: ['PF1_stretch_uzy.srd', 'hsc_uzy/base#base-y']
+base: ['PF1_stretch_uzy.srd', 'hsc_uzy/base#hsc-y']

--- a/specs/validate_drp/hsc_uzy/base.yaml
+++ b/specs/validate_drp/hsc_uzy/base.yaml
@@ -1,28 +1,29 @@
 # Specifications for validate_drp metrics against validation_data_hsc
-# uzy-band datasets. 
+# uzy-band datasets.
 
 ---
 # Select the HSC test dataset
-id: 'base'
+id: 'hsc'
 metadata_query:
   instrument: 'HSC'
   dataset_repo_url: 'https://github.com/lsst/validation_data_hsc.git'
+  dataset_name: validation_data_hsc
   # may need to add some visits
 
 ---
-id: 'base-u'
-base: '#base'
+id: 'hsc-u'
+base: '#hsc'
 metadata_query:
   filter_name: 'HSC-U'
 
 ---
-id: 'base-z'
-base: '#base'
+id: 'hsc-z'
+base: '#hsc'
 metadata_query:
   filter_name: 'HSC-Z'
 
 ---
-id: 'base-y'
-base: '#base'
+id: 'hsc-y'
+base: '#hsc'
 metadata_query:
   filter_name: 'HSC-Y'


### PR DESCRIPTION
- Added tags to identify astrometry, photometry, image_quality metrics, and specification thresholds like minimum, design and and stretch in the `validate_drp` package. 
- Added dataset_name to query metadata for validate_drp specifications this way SQuaSH can query specifications based on datataset name.

These changes are required by the SQuaSH API in order to query metrics and specifications to feed the KPMs dashboard.

****

- [X] Passes Jenkins CI.
- [X] Documentation is up-to-date.