### PR TITLE
DM-16319: Add Association metrics.

### DIFF
--- a/metrics/ap_association.yaml
+++ b/metrics/ap_association.yaml
@@ -3,7 +3,7 @@
 AssociationTime: &RunningTime
     description: Total time elapsed in AssociationTask.
     unit: s
-    reference:
+    reference: &ApMetrics
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
     tags:
         - ap_verify
@@ -11,3 +11,30 @@ AssociationTime: &RunningTime
         - task
         - monitoring
 
+numNewDiaObjects: &SourceCount
+    description: Number of DIASources that create new DIAObjects in this image.
+    unit: ct
+    reference: *ApMetrics
+    tags: &DiffimCcdMetric !!set
+        ? ap_verify
+        ? diffim
+        ? assoc
+        ? CCD
+
+numUnassociatedDiaObjects:
+    <<: *SourceCount
+    description: Number of previously-known DIAObjects that do not have detected DIASources here.
+
+totalUnassociatedDiaObjects:
+    <<: *SourceCount
+    description: Number of DIAObjects that are only detected once
+    tags: &DatasetMetric !!set
+        ? ap_verify
+        ? assoc
+        ? dataset
+
+fracUpdatedDiaObjects: &SourceFraction
+    description: Fraction of known previously-known DIAObjects that have detected DIAsources here.
+    unit: '%'
+    reference: *ApMetrics
+    tags: *DiffimCcdMetric

--- a/metrics/ip_diffim.yaml
+++ b/metrics/ip_diffim.yaml
@@ -3,7 +3,7 @@
 ImagePsfMatchTime: &RunningTime
     description: Total time elapsed in ImagePsfMatchTask.
     unit: s
-    reference:
+    reference: &ApMetrics
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
     tags:
         - ap_verify
@@ -15,3 +15,19 @@ DipoleFitTime:
     <<: *RunningTime
     description: Total time elapsed in DipoleFitTask.
 
+fracDiaSourcesToSciSources:
+    description: fraction of DIASources/science sources
+    unit: '%'
+    reference: *ApMetrics
+    tags: &CcdMetric !!set
+        ? ap_verify
+        ? diffim
+        ? CCD
+
+numSciSources:
+    description: Number of DIASources (positive and negative)
+    unit: ct
+    reference: *ApMetrics
+    tags: !!set
+        <<: *CcdMetric
+        ? monitoring


### PR DESCRIPTION
This PR adds several metrics that are associated with `ap_association`. These metrics were previously available in `ap_verify` dumps but were not included in `verify_metrics` by mistake.