### PR TITLE
DM-16400: Create a timing metric for ApPipeTask

### DIFF
--- a/metrics/ap_pipe.yaml
+++ b/metrics/ap_pipe.yaml
@@ -1,0 +1,13 @@
+# Metric definitions in ap_pipe
+
+ApPipeTime: &RunningTime
+    description: Total time elapsed in ApPipeTask.
+    unit: s
+    reference:
+        url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
+    tags:
+        - ap_verify
+        - workflow
+        - pipeline
+        - monitoring
+


### PR DESCRIPTION
This PR adds a metric for extracting timing information from `ApPipeTask` itself; its subtasks are already covered by existing metrics.