### PR TITLE
DM-16536: Migrate all metrics from ap.verify.measurements

### DIFF
--- a/metrics/ap_association.yaml
+++ b/metrics/ap_association.yaml
@@ -1,7 +1,7 @@
 # Metric definitions in ap_association
 
 AssociationTime: &RunningTime
-    description: Total time elapsed in AssociationTask.
+    description: Wall-clock time elapsed in AssociationTask.
     unit: s
     reference: &ApMetrics
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics

--- a/metrics/ap_pipe.yaml
+++ b/metrics/ap_pipe.yaml
@@ -1,7 +1,7 @@
 # Metric definitions in ap_pipe
 
 ApPipeTime: &RunningTime
-    description: Total time elapsed in ApPipeTask.
+    description: Wall-clock time elapsed in ApPipeTask.
     unit: s
     reference:
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics

--- a/metrics/ap_verify.yaml
+++ b/metrics/ap_verify.yaml
@@ -1,7 +1,7 @@
 # Metric definitions in ap_verify
 
 WallClockTime: &RunningTime
-    description: Total time elapsed in the pipeline.
+    description: Wall-clock time elapsed in the pipeline.
     unit: s
     reference:
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics

--- a/metrics/ip_diffim.yaml
+++ b/metrics/ip_diffim.yaml
@@ -1,7 +1,7 @@
 # Metric definitions in ip_diffim
 
 ImagePsfMatchTime: &RunningTime
-    description: Total time elapsed in ImagePsfMatchTask.
+    description: Wall-clock time elapsed in ImagePsfMatchTask.
     unit: s
     reference: &ApMetrics
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
@@ -13,7 +13,7 @@ ImagePsfMatchTime: &RunningTime
 
 DipoleFitTime:
     <<: *RunningTime
-    description: Total time elapsed in DipoleFitTask.
+    description: Wall-clock time elapsed in DipoleFitTask.
 
 fracDiaSourcesToSciSources:
     description: fraction of DIASources/science sources

--- a/metrics/ip_isr.yaml
+++ b/metrics/ip_isr.yaml
@@ -1,7 +1,7 @@
 # Metric definitions in ip_isr
 
 IsrTime: &RunningTime
-    description: Total time elapsed in IsrTask.
+    description: Wall-clock time elapsed in IsrTask.
     unit: s
     reference:
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics

--- a/metrics/meas_algorithms.yaml
+++ b/metrics/meas_algorithms.yaml
@@ -1,7 +1,7 @@
 # Metric definitions in meas_algorithms
 
 SourceDetectionTime: &RunningTime
-    description: Total time elapsed in SourceDetectionTask.
+    description: Wall-clock time elapsed in SourceDetectionTask.
     unit: s
     reference:
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics

--- a/metrics/meas_astrom.yaml
+++ b/metrics/meas_astrom.yaml
@@ -1,7 +1,7 @@
 # Metric definitions in meas_astrom
 
 AstrometryTime: &RunningTime
-    description: Total time elapsed in AstrometryTask.
+    description: Wall-clock time elapsed in AstrometryTask.
     unit: s
     reference:
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics

--- a/metrics/pipe_tasks.yaml
+++ b/metrics/pipe_tasks.yaml
@@ -1,7 +1,7 @@
 # Metric definitions in pipe_tasks
 
 ProcessCcdTime: &RunningTime
-    description: Total time elapsed in ProcessCcdTask.
+    description: Wall-clock time elapsed in ProcessCcdTask.
     unit: s
     reference:
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
@@ -13,17 +13,17 @@ ProcessCcdTime: &RunningTime
 
 CharacterizeImageTime:
     <<: *RunningTime
-    description: Total time elapsed in CharacterizeImageTask.
+    description: Wall-clock time elapsed in CharacterizeImageTask.
 
 CalibrateTime:
     <<: *RunningTime
-    description: Total time elapsed in CalibrateTask.
+    description: Wall-clock time elapsed in CalibrateTask.
 
 ImageDifferenceTime:
     <<: *RunningTime
-    description: Total time elapsed in ImageDifferenceTask.
+    description: Wall-clock time elapsed in ImageDifferenceTask.
 
 RegisterImageTime:
     <<: *RunningTime
-    description: Total time elapsed in registerImage.RegisterTask.
+    description: Wall-clock time elapsed in registerImage.RegisterTask.
 


### PR DESCRIPTION
This PR updates the documentation of all timing metrics to clarify that they measure wall-clock time.