### PR TITLE
DM-20702: Create memory usage metric

### DIFF
--- a/metrics/ap_association.yaml
+++ b/metrics/ap_association.yaml
@@ -11,6 +11,21 @@ AssociationTime: &RunningTime
         - task
         - monitoring
 
+AssociationMemory: &Memory
+    description: Maximum resident set size in any AssociationTask process.
+    unit: byte
+    reference:
+        url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
+    tags:
+        - ap_verify
+        - workflow
+        - task
+        - monitoring
+
+DiaForcedSourceMemory:
+    <<: *Memory
+    description: Maximum resident set size in any DiaForcedSourceTask process.
+
 numNewDiaObjects: &SourceCount
     description: Number of DIASources that create new DIAObjects in this image.
     unit: ct

--- a/metrics/ap_pipe.yaml
+++ b/metrics/ap_pipe.yaml
@@ -11,3 +11,14 @@ ApPipeTime: &RunningTime
         - task
         - monitoring
 
+ApPipeMemory: &Memory
+    description: Maximum resident set size in any ApPipeTask process.
+    unit: byte
+    reference:
+        url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
+    tags:
+        - ap_verify
+        - workflow
+        - task
+        - monitoring
+

--- a/metrics/ap_pipe.yaml
+++ b/metrics/ap_pipe.yaml
@@ -8,6 +8,6 @@ ApPipeTime: &RunningTime
     tags:
         - ap_verify
         - workflow
-        - pipeline
+        - task
         - monitoring
 

--- a/metrics/pipe_tasks.yaml
+++ b/metrics/pipe_tasks.yaml
@@ -27,3 +27,18 @@ RegisterImageTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in registerImage.RegisterTask.
 
+ProcessCcdMemory: &Memory
+    description: Maximum resident set size in any ProcessCcdTask process.
+    unit: byte
+    reference:
+        url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
+    tags:
+        - ap_verify
+        - workflow
+        - task
+        - monitoring
+
+ImageDifferenceMemory:
+    <<: *Memory
+    description: Maximum resident set size in any ImageDifferenceTask process.
+


### PR DESCRIPTION
This PR adds memory metrics for `ApPipeTask` and its immediate subtasks.