### PR TITLE
DM-21320: Add first metric to colorAnalysis

### DIFF
--- a/metrics/pipe_analysis.yaml
+++ b/metrics/pipe_analysis.yaml
@@ -1,0 +1,33 @@
+# Metric definitions in pipe_analysis
+
+stellar_locus_width_wPerp:
+  description: >
+    The rms width of the "wPerp" Principal Color stellar locus (a la Ivezic et al. 2004):
+    the blue section on the r-i vs g-r plane using PSF fluxes.
+  unit: mmag
+  reference:
+    doc: Ivezic, Z. et al. 2004, AN 325, SDSS data management and photometric quality assessment
+    url: https://onlinelibrary.wiley.com/doi/pdf/10.1002/asna.200410285
+    page: 586
+  tags:
+      - photometry
+      - stellarLocus
+      - coadd
+      - PSFflux
+      - colorAnalysisTask
+
+stellar_locus_width_xPerp:
+  description: >
+    The rms width of the "xPerp" Principal Color stellar locus (a la Ivezic et al. 2004):
+    the red section on the r-i vs g-r plane using PSF fluxes.
+  unit: mmag
+  reference:
+    doc: Ivezic, Z. et al. 2004, AN 325, SDSS data management and photometric quality assessment
+    url: https://onlinelibrary.wiley.com/doi/pdf/10.1002/asna.200410285
+    page: 586
+  tags:
+      - photometry
+      - stellarLocus
+      - coadd
+      - PSFflux
+      - colorAnalysisTask

--- a/specs/pipe_analysis/colorAnalysis/stellar_locus_width.yaml
+++ b/specs/pipe_analysis/colorAnalysis/stellar_locus_width.yaml
@@ -1,0 +1,38 @@
+# Stellar locus specifications for pipe_analysis
+#
+# These specifications don't query against provenance; sub-specifications
+# *can* inherit these, though, to concretely test against a certain dataset.
+
+---
+# Specification partial
+id: "stellar_locus_width-base"
+threshold:
+  operator: "<="
+  unit: "mmag"
+tags:
+  - "stellar_locus_width"
+  - "minimum"
+
+# pipe_analysis.stellar_locas_width_wPerp.griPSF_wFit
+---
+name: "griPSF_wFit"
+base: "#stellar_locus_width-base"
+metric: "stellar_locus_width_wPerp"
+threshold:
+  value: 25.0
+tags:
+  - "gri"
+metadata_query:
+  filter_name: "HSC-G^HSC-R^HSC-I"
+
+# pipe_analysis.stellar_locas_width_xPerp.griPSF_xFit
+---
+name: "griPSF_xFit"
+base: "#stellar_locus_width-base"
+metric: "stellar_locus_width_xPerp"
+threshold:
+  value: 50.0
+tags:
+  - "gri"
+metadata_query:
+  filter_name: "HSC-G^HSC-R^HSC-I"


### PR DESCRIPTION
This adds the first metric, stellar_w_principal_color_rms_width_gri,
computed by the colorAnalysisTask in pipe_analysis.

{Summary of changes. Prefix PR title with ticket handle.}

****

- [ ] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
