### PR TITLE
DM-25450: Add Rowe statistics to SQuaSH

### DIFF
--- a/metrics/pipe_analysis.yaml
+++ b/metrics/pipe_analysis.yaml
@@ -68,3 +68,145 @@ fake_stars_magDiffSigMad_base_CircAper_12_0_mag:
       - photometry
       - fakes
 
+# Base metric definition for RhoStatistics
+rhoStatistics_base: &rhoStatistics_base
+  unit: ""
+  reference:
+    doc:
+      - Rowe, B. 2010, MNRAS Volume 404, Issue 1, p. 350-366
+      - Jarvis, M. 2016, MNRAS Volume 460, Issue 2, p. 2245-2281
+    url:
+      - https://ui.adsabs.harvard.edu/abs/2010MNRAS.404..350R/abstract
+      - https://ui.adsabs.harvard.edu/abs/2016MNRAS.460.2245J/abstract
+  tags: &rhoTags
+      - RhoStatistics
+      - VisitAnalysisTask
+      - CoaddAnalysisTask
+  description: >
+      Base class for rhoStatistics
+
+# RhoStatistics 0
+rhoStatistics0_HSM_smallScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 0 statistic measured with HSM shapes for all stars within 1 arcmin.
+
+rhoStatistics0_HSM_smallScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 0 statistic measured with HSM shapes for PSF stars within 1 arcmin.
+
+rhoStatistics0_HSM_largeScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 0 statistic measured with HSM shapes for all stars separated by more than 1 arcmin.
+
+rhoStatistics0_HSM_largeScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 0 statistic measured with HSM shapes for PSF stars separated by more 1 arcmin.
+
+# RhoStatistics 1
+rhoStatistics1_HSM_smallScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 1 statistic measured with HSM shapes for all stars within 1 arcmin.
+
+rhoStatistics1_HSM_smallScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 1 statistic measured with HSM shapes for PSF stars within 1 arcmin.
+
+rhoStatistics1_HSM_largeScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 1 statistic measured with HSM shapes for all stars separated by more than 1 arcmin.
+
+rhoStatistics1_HSM_largeScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 1 statistic measured with HSM shapes for PSF stars separated by more 1 arcmin.
+
+# RhoStatistics 2
+rhoStatistics2_HSM_smallScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 2 statistic measured with HSM shapes for all stars within 1 arcmin.
+
+rhoStatistics2_HSM_smallScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 2 statistic measured with HSM shapes for PSF stars within 1 arcmin.
+
+rhoStatistics2_HSM_largeScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 2 statistic measured with HSM shapes for all stars separated by more than 1 arcmin.
+
+rhoStatistics2_HSM_largeScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 2 statistic measured with HSM shapes for PSF stars separated by more 1 arcmin.
+
+# RhoStatistics 3
+rhoStatistics3_HSM_smallScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 3 statistic measured with HSM shapes for all stars within 1 arcmin.
+
+rhoStatistics3_HSM_smallScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 3 statistic measured with HSM shapes for PSF stars within 1 arcmin.
+
+rhoStatistics3_HSM_largeScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 3 statistic measured with HSM shapes for all stars separated by more than 1 arcmin.
+
+rhoStatistics3_HSM_largeScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 3 statistic measured with HSM shapes for PSF stars separated by more 1 arcmin.
+
+# RhoStatistics 4
+rhoStatistics4_HSM_smallScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 4 statistic measured with HSM shapes for all stars within 1 arcmin.
+
+rhoStatistics4_HSM_smallScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 4 statistic measured with HSM shapes for PSF stars within 1 arcmin.
+
+rhoStatistics4_HSM_largeScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 4 statistic measured with HSM shapes for all stars separated by more than 1 arcmin.
+
+rhoStatistics4_HSM_largeScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 4 statistic measured with HSM shapes for PSF stars separated by more 1 arcmin.
+
+# RhoStatistics 5
+rhoStatistics5_HSM_smallScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 5 statistic measured with HSM shapes for all stars within 1 arcmin.
+
+rhoStatistics5_HSM_smallScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 5 statistic measured with HSM shapes for PSF stars within 1 arcmin.
+
+rhoStatistics5_HSM_largeScale_allStars:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 5 statistic measured with HSM shapes for all stars separated by more than 1 arcmin.
+
+rhoStatistics5_HSM_largeScale_calibPsfUsed:
+  <<: *rhoStatistics_base
+  description: >
+    Mean Rho 5 statistic measured with HSM shapes for PSF stars separated by more 1 arcmin.

--- a/specs/pipe_analysis/coaddAnalysis/rhoStatistics.yaml
+++ b/specs/pipe_analysis/coaddAnalysis/rhoStatistics.yaml
@@ -1,0 +1,116 @@
+# Rho statistics from pipe_analysis
+#
+# Note that the PSF ellipticity residuals represented by the Rho 1 statistic
+# are not included here, but they are captured by the TE1 and TE2 metrics
+# (located in `verify_metrics/specs/validate_drp\TEx.yaml`).
+
+---
+# Specification partial
+id: "rhoStatistics_smallScale-base"
+threshold:
+  operator: "<="
+  unit: ""
+  reference:
+    doc: Jarvis, M. et al. 2016, MNRAS, Vol. 460, Issue 2,
+         "The DES Science Verification weak lensing shear catalogues"
+    url: https://ui.adsabs.harvard.edu/abs/2016MNRAS.460.2245J/abstract
+    page: 2245
+tags:
+  - "rhoStatistics_smallScale"
+  - "rhoStatistics"
+
+---
+id: "rhoStatistics_HSM"
+metadata_query:
+  shapeAlgorithm: "HSM"
+tags:
+  - "HSM"
+
+---
+id: "calibPsfUsed"
+metadata_query:
+  catalog: "calibPsfUsed"
+tags:
+  - "calibPsfUsed"
+
+---
+id: "allStars"
+metadata_query:
+  catalog: "allStars"
+tags:
+  "allStars"
+
+# pipe_analysis.rhoStatistics0
+---
+name: "HSM_smallScale_calibPsfUsed"
+base: ["#rhoStatistics_smallScale-base", "#rhoStatistics_HSM", "#calibPsfUsed"]
+metric: rhoStatistics0_HSM_smallScale_calibPsfUsed
+threshold:
+  value: 1e-6
+
+---
+name: "HSM_smallScale_allStars"
+base: ["#rhoStatistics_smallScale-base", "#rhoStatistics_HSM", "#allStars"]
+metric: rhoStatistics0_HSM_smallScale_allStars
+threshold:
+  value: 1e-5
+
+# pipe_analysis.rhoStatistics2
+---
+name: "HSM_smallScale_calibPsfUsed"
+base: ["#rhoStatistics_smallScale-base", "#rhoStatistics_HSM", "#calibPsfUsed"]
+metric: rhoStatistics2_HSM_smallScale_calibPsfUsed
+threshold:
+  value: 1e-6
+
+---
+name: "HSM_smallScale_allStars"
+base: ["#rhoStatistics_smallScale-base", "#rhoStatistics_HSM", "#allStars"]
+metric: rhoStatistics2_HSM_smallScale_allStars
+threshold:
+  value: 1e-5
+
+# pipe_analysis.rhoStatistics3
+---
+name: "HSM_smallScale_calibPsfUsed"
+base: ["#rhoStatistics_smallScale-base", "#rhoStatistics_HSM", "#calibPsfUsed"]
+metric: rhoStatistics3_HSM_smallScale_calibPsfUsed
+threshold:
+  value: 1e-6
+
+---
+name: "HSM_smallScale_allStars"
+base: ["#rhoStatistics_smallScale-base", "#rhoStatistics_HSM", "#allStars"]
+metric: rhoStatistics3_HSM_smallScale_allStars
+threshold:
+  value: 1e-5
+
+# pipe_analysis.rhoStatistics4
+---
+name: "HSM_smallScale_calibPsfUsed"
+base: ["#rhoStatistics_smallScale-base", "#rhoStatistics_HSM", "#calibPsfUsed"]
+metric: rhoStatistics4_HSM_smallScale_calibPsfUsed
+threshold:
+  value: 1e-6
+
+---
+name: "HSM_smallScale_allStars"
+base: ["#rhoStatistics_smallScale-base", "#rhoStatistics_HSM", "#allStars"]
+metric: rhoStatistics4_HSM_smallScale_allStars
+threshold:
+  value: 1e-5
+
+# pipe_analysis.rhoStatistics5
+---
+name: "HSM_smallScale_calibPsfUsed"
+base: ["#rhoStatistics_smallScale-base", "#rhoStatistics_HSM", "#calibPsfUsed"]
+metric: rhoStatistics5_HSM_smallScale_calibPsfUsed
+threshold:
+  value: 1e-6
+
+---
+name: "HSM_smallScale_allStars"
+base: ["#rhoStatistics_smallScale-base", "#rhoStatistics_HSM", "#allStars"]
+metric: rhoStatistics5_HSM_smallScale_allStars
+threshold:
+  value: 1e-5


### PR DESCRIPTION
This PR defines new metrics related to Rho Statistics computed from star catalogs in `lsst-dm/pipe_analysis`. There is an [associated PR](https://github.com/lsst-dm/pipe_analysis/pull/60) which includes the code for measurement of these metrics.
