### PR TITLE
DM-32502: Add TE3 and TE4 to validate_drp.yaml

### DIFF
--- a/metrics/validate_drp.yaml
+++ b/metrics/validate_drp.yaml
@@ -518,7 +518,7 @@ TE1:
   reference:
     doc: LPM-17
     url: http://ls.st/lpm-17
-    page: 31
+    page: 38
   unit: ''
   description: >
     The averaged E1, E2, and Ex residual PSF ellipticity correlations
@@ -529,7 +529,7 @@ TE2:
   reference:
     doc: LPM-17
     url: http://ls.st/lpm-17
-    page: 31
+    page: 38
   unit: ''
   description: >
     The averaged E1, E2, and Ex residual PSF ellipticity correlations
@@ -551,7 +551,7 @@ TE4:
   reference:
     doc: LPM-17
     url: http://ls.st/lpm-17
-    page: 31
+    page: 38
   unit: ''
   description: >
     The averaged E1, E2, and Ex residual PSF ellipticity correlations from visits

--- a/metrics/validate_drp.yaml
+++ b/metrics/validate_drp.yaml
@@ -536,6 +536,28 @@ TE2:
     must have median absolute value less than this for separations > 5 arcmin.
   tags: image_quality
 
+TE3:
+  reference:
+    doc: LPM-17
+    url: http://ls.st/lpm-17
+    page: 38
+  unit: ''
+  description: >
+    The averaged E1, E2, and Ex residual PSF ellipticity correlations from visits
+    must have median absolute value less than this for separations < 5 arcmin.
+  tags: image_quality
+
+TE4:
+  reference:
+    doc: LPM-17
+    url: http://ls.st/lpm-17
+    page: 31
+  unit: ''
+  description: >
+    The averaged E1, E2, and Ex residual PSF ellipticity correlations from visits
+    must have median absolute value less than this for separations > 5 arcmin.
+  tags: image_quality
+
 modelPhotRepGal1:
   description: >
     The maximum rms of the resolved source model magnitude distribution around the mean value in the 1st faintest bin.


### PR DESCRIPTION
Added definitions of metrics TE3 and TE4 to validate_drp.yaml. This will (hopefully) fix the failures of nightly CI job `verify_drp_metrics`, which is failing when the job reporter tries to look up the specs for these metrics.

Jenkins is running at: https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/35352/pipeline
