### PR TITLE
DM-32544: Add specs for TE3 and TE4

### DIFF
--- a/specs/validate_drp/TEx.yaml
+++ b/specs/validate_drp/TEx.yaml
@@ -22,6 +22,26 @@ threshold:
   operator: "<="
 
 ---
+id: 'TE3-base'
+metric: 'TE3'
+tags:
+  - 'TE3'
+  - 'achromatic'
+threshold:
+  unit: ''
+  operator: "<="
+
+---
+id: 'TE4-base'
+metric: 'TE4'
+tags:
+  - 'TE4'
+  - 'achromatic'
+threshold:
+  unit: ''
+  operator: "<="
+
+---
 name: "design"
 base: "#TE1-base"
 threshold:
@@ -49,7 +69,7 @@ tags:
 name: "design"
 base: "#TE2-base"
 threshold:
-  value: 0.00005
+  value: 0.0000001
 tags:
   - design
 
@@ -57,7 +77,7 @@ tags:
 name: "minimum"
 base: "#TE2-base"
 threshold:
-  value: 0.00003
+  value: 0.0000003
 tags:
   - minimum
 
@@ -65,6 +85,54 @@ tags:
 name: "stretch"
 base: "#TE2-base"
 threshold:
-  value: 0.00001
+  value: 0.00000005
+tags:
+  - stretch
+
+---
+name: "design"
+base: "#TE3-base"
+threshold:
+  value: 0.00004
+tags:
+  - design
+
+---
+name: "minimum"
+base: "#TE3-base"
+threshold:
+  value: 0.00006
+tags:
+  - minimum
+
+---
+name: "stretch"
+base: "#TE3-base"
+threshold:
+  value: 0.00002
+tags:
+  - stretch
+
+---
+name: "design"
+base: "#TE4-base"
+threshold:
+  value: 0.0000002
+tags:
+  - design
+
+---
+name: "minimum"
+base: "#TE4-base"
+threshold:
+  value: 0.0000005
+tags:
+  - minimum
+
+---
+name: "stretch"
+base: "#TE4-base"
+threshold:
+  value: 0.0000001
 tags:
   - stretch


### PR DESCRIPTION
Added TE3 and TE4 metric specs to validate_drp. I also updated the TE1 and TE2 values to be consistent with the SRD definitions.

Jenkins job kicked off at https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/35377/pipeline