### PR TITLE
DM-31860: Add flux stat task and sky obj metrics into faro

### DIFF
--- a/metrics/pipe_analysis.yaml
+++ b/metrics/pipe_analysis.yaml
@@ -211,7 +211,7 @@ rhoStatistics5_HSM_largeScale_calibPsfUsed:
   description: >
     Mean Rho 5 statistic measured with HSM shapes for PSF stars separated by more 1 arcmin.
 
-skyObjectMean_CircApRad9pix:
+skyObjectMean_ap09Flux:
   description: >
     The mean value of the sigma-clipped sky object base_CircularApertureFlux_9_0_instFlux data.
   unit: nanojansky
@@ -219,7 +219,7 @@ skyObjectMean_CircApRad9pix:
   - skyObject
   - skyLevel
 
-skyObjectStd_CircApRad9pix:
+skyObjectStd_ap09Flux:
   description: >
     The standard deviation of the sigma-clipped sky object base_CircularApertureFlux_9_0_instFlux data.
   unit: nanojansky

--- a/specs/pipe_analysis/coaddAnalysis/skyObject.yaml
+++ b/specs/pipe_analysis/coaddAnalysis/skyObject.yaml
@@ -1,8 +1,8 @@
 # Sky object specifications for pipe_analysis
 
-# pipe_analysis.skyObjectMean_CircApRad9pix.lower
+# pipe_analysis.skyObjectMean_ap09Flux.lower
 ---
-metric: "skyObjectMean_CircApRad9pix"
+metric: "skyObjectMean_ap09Flux"
 name: "lower"
 threshold:
   operator: ">="
@@ -11,9 +11,9 @@ threshold:
 tags:
   - "lower"
 
-# pipe_analysis.skyObjectMean_CircApRad9pix.upper
+# pipe_analysis.skyObjectMean_ap09Flux.upper
 ---
-metric: "skyObjectMean_CircApRad9pix"
+metric: "skyObjectMean_ap09Flux"
 name: "upper"
 threshold:
   operator: "<="
@@ -22,9 +22,9 @@ threshold:
 tags:
   - "upper"
 
-# pipe_analysis.skyObjectStd_CircApRad9pix.minimum
+# pipe_analysis.skyObjectStd_ap09Flux.minimum
 ---
-metric: "skyObjectStd_CircApRad9pix"
+metric: "skyObjectStd_ap09Flux"
 name: "minimum"
 threshold:
   operator: "<="


### PR DESCRIPTION
This commit updates the sky object metric task name suffixes to match
the names of the flux columns used for metric calculation.

{Summary of changes. Prefix PR title with ticket handle.}

****

- [x] Passes Jenkins CI.
- [x] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
