### PR TITLE
DM-37302: Add dedicated metrics for CPU time

### DIFF
--- a/metrics/ap_association.yaml
+++ b/metrics/ap_association.yaml
@@ -17,7 +17,7 @@ DiaPipelineTime:
 
 MapDiaSourceTime:
     <<: *RunningTime
-    description: Wall-clock time elapsed in MapDiaSourceTask.
+    description: Wall-clock time elapsed in MapDiaSourceTask or TransformDiaSourceCatalogTask.
 
 LoadDiaCatalogsTime:
     <<: *RunningTime

--- a/metrics/ap_association.yaml
+++ b/metrics/ap_association.yaml
@@ -10,26 +10,50 @@ AssociationTime: &RunningTime
         - workflow
         - task
         - monitoring
+AssociationCpuTime: &CpuTime
+    description: CPU time elapsed in AssociationTask.
+    unit: s
+    reference:
+        <<: *ApMetrics
+    tags:
+        - ap_verify
+        - workflow
+        - task
 
 DiaPipelineTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in DiaPipelineTask.
+DiaPipelineCpuTime:
+    <<: *CpuTime
+    description: CPU time elapsed in DiaPipelineTask.
 
 MapDiaSourceTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in MapDiaSourceTask or TransformDiaSourceCatalogTask.
+MapDiaSourceCpuTime:
+    <<: *CpuTime
+    description: CPU time elapsed in MapDiaSourceTask or TransformDiaSourceCatalogTask.
 
 LoadDiaCatalogsTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in LoadDiaCatalogsTask.
+LoadDiaCatalogsCpuTime:
+    <<: *CpuTime
+    description: CPU time elapsed in LoadDiaCatalogsTask.
 
 DiaForcedSourceTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in DiaForcedSourceTask.
+DiaForcedSourceCpuTime:
+    <<: *CpuTime
+    description: CPU time elapsed in DiaForcedSourceTask.
 
 PackageAlertsTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in PackageAlertsTask.
+PackageAlertsCpuTime:
+    <<: *CpuTime
+    description: CPU time elapsed in PackageAlertsTask.
 
 AssociationMemory: &Memory
     description: Maximum resident set size in or before any AssociationTask process.

--- a/metrics/ap_pipe.yaml
+++ b/metrics/ap_pipe.yaml
@@ -1,27 +1,5 @@
 # Metric definitions in ap_pipe
 
-ApPipeTime: &RunningTime
-    description: Wall-clock time elapsed in ApPipeTask.
-    unit: s
-    reference:
-        url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
-    tags:
-        - ap_verify
-        - workflow
-        - task
-        - monitoring
-
-ApPipeMemory: &Memory
-    description: Maximum resident set size in or before any ApPipeTask process.
-    unit: byte
-    reference:
-        url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
-    tags:
-        - ap_verify
-        - workflow
-        - task
-        - monitoring
-
 ApFakesCompletenessMag20t22: &Completeness
     description: Completeness of recovered fakes in the magnitudes range 20-22. This is related to transCompletenessMin, OSS-REQ-0353.
     unit: '%'

--- a/metrics/ip_diffim.yaml
+++ b/metrics/ip_diffim.yaml
@@ -10,18 +10,36 @@ ImagePsfMatchTime: &RunningTime
         - workflow
         - task
         - monitoring
+ImagePsfMatchCpuTime: &CpuTime
+    description: CPU time elapsed in ImagePsfMatchTask.
+    unit: s
+    reference:
+        <<: *ApMetrics
+    tags:
+        - ap_verify
+        - workflow
+        - task
 
 DipoleFitTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in DipoleFitTask.
+DipoleFitCpuTime:
+    <<: *CpuTime
+    description: CPU time elapsed in DipoleFitTask.
 
 SubtractImagesALTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in AlardLuptonSubtractTask.
+SubtractImagesALCpuTime:
+    <<: *CpuTime
+    description: CPU time elapsed in AlardLuptonSubtractTask.
 
 DetectAndMeasureTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in DetectAndMeasureTask.
+DetectAndMeasureCpuTime:
+    <<: *CpuTime
+    description: CPU time elapsed in DetectAndMeasureTask.
 
 fracDiaSourcesToSciSources:
     description: fraction of DIASources/science sources

--- a/metrics/ip_isr.yaml
+++ b/metrics/ip_isr.yaml
@@ -3,11 +3,19 @@
 IsrTime: &RunningTime
     description: Wall-clock time elapsed in IsrTask.
     unit: s
-    reference:
+    reference: &ApMetrics
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
     tags:
         - ap_verify
         - workflow
         - task
         - monitoring
-
+IsrCpuTime: &CpuTime
+    description: CPU time elapsed in IsrTask.
+    unit: s
+    reference:
+        <<: *ApMetrics
+    tags:
+        - ap_verify
+        - workflow
+        - task

--- a/metrics/meas_algorithms.yaml
+++ b/metrics/meas_algorithms.yaml
@@ -3,11 +3,19 @@
 SourceDetectionTime: &RunningTime
     description: Wall-clock time elapsed in SourceDetectionTask.
     unit: s
-    reference:
+    reference: &ApMetrics
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
     tags:
         - ap_verify
         - workflow
         - task
         - monitoring
-
+SourceDetectionCpuTime: &CpuTime
+    description: CPU time elapsed in SourceDetectionTask.
+    unit: s
+    reference:
+        <<: *ApMetrics
+    tags:
+        - ap_verify
+        - workflow
+        - task

--- a/metrics/meas_astrom.yaml
+++ b/metrics/meas_astrom.yaml
@@ -3,11 +3,19 @@
 AstrometryTime: &RunningTime
     description: Wall-clock time elapsed in AstrometryTask.
     unit: s
-    reference:
+    reference: &ApMetrics
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
     tags:
         - ap_verify
         - workflow
         - task
         - monitoring
-
+AstrometryCpuTime: &CpuTime
+    description: CPU time elapsed in AstrometryTask.
+    unit: s
+    reference:
+        <<: *ApMetrics
+    tags:
+        - ap_verify
+        - workflow
+        - task

--- a/metrics/pipe_tasks.yaml
+++ b/metrics/pipe_tasks.yaml
@@ -10,10 +10,22 @@ CharacterizeImageTime: &RunningTime
         - workflow
         - task
         - monitoring
+CharacterizeImageCpuTime: &CpuTime
+    description: CPU time elapsed in CharacterizeImageTask.
+    unit: s
+    reference:
+        <<: *ApMetrics
+    tags:
+        - ap_verify
+        - workflow
+        - task
 
 CalibrateTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in CalibrateTask.
+CalibrateCpuTime:
+    <<: *CpuTime
+    description: CPU time elapsed in CalibrateTask.
 
 numDeblendedSciSources:
     description: Number of direct imaging sources that have been deblended.

--- a/metrics/pipe_tasks.yaml
+++ b/metrics/pipe_tasks.yaml
@@ -1,7 +1,7 @@
 # Metric definitions in pipe_tasks
 
-ProcessCcdTime: &RunningTime
-    description: Wall-clock time elapsed in ProcessCcdTask.
+CharacterizeImageTime: &RunningTime
+    description: Wall-clock time elapsed in CharacterizeImageTask.
     unit: s
     reference: &ApMetrics
         url: https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=~ebellm&title=Alert+Production+Metrics
@@ -11,24 +11,9 @@ ProcessCcdTime: &RunningTime
         - task
         - monitoring
 
-CharacterizeImageTime:
-    <<: *RunningTime
-    description: Wall-clock time elapsed in CharacterizeImageTask.
-
 CalibrateTime:
     <<: *RunningTime
     description: Wall-clock time elapsed in CalibrateTask.
-
-ProcessCcdMemory: &Memory
-    description: Maximum resident set size in or before any ProcessCcdTask process.
-    unit: byte
-    reference:
-        <<: *ApMetrics
-    tags:
-        - ap_verify
-        - workflow
-        - task
-        - monitoring
 
 numDeblendedSciSources:
     description: Number of direct imaging sources that have been deblended.


### PR DESCRIPTION
This PR adds new AP timing metrics that record CPU time rather than wall-clock time. These metrics are analogous to the existing wall-clock metrics.