### PR TITLE
DM-40400: Create total AP pipeline timing metric

### DIFF
--- a/metrics/ap_pipe.yaml
+++ b/metrics/ap_pipe.yaml
@@ -35,3 +35,12 @@ ApFakesCountMag22t24:
 ApFakesCountMag24t26:
     <<: *FakeCount
     description: Number of fakes inserted in the magnitude range 24-26. Denominator in ApFakesCompletenessMag24t26.
+
+ApPipelineTime:
+    description: Wall-clock time elapsed when running the entire AP pipeline.
+    unit: s
+    tags:
+        - ap_verify
+        - workflow
+        - pipeline
+        - monitoring


### PR DESCRIPTION
This PR registers a metric representing the wall-clock time of the entire pipeline. In practice, it seems to be dominated by scheduling or resource contention; the ratio of total pipeline time to the sum of the individual task times grows with the size of the dataset.

The metric is implemented on lsst/ap_pipe#168.

****

- [X] Passes Jenkins CI.
- [ ] Documentation is up-to-date.